### PR TITLE
Created module to deploy OPA Gatekeeper

### DIFF
--- a/katalog/opa-gatekeeper/audit.yml
+++ b/katalog/opa-gatekeeper/audit.yml
@@ -1,0 +1,15 @@
+apiVersion: config.gatekeeper.sh/v1alpha1
+kind: Config
+metadata:
+  name: config
+  namespace: "gatekeeper-system"
+spec:
+  # Data to be replicated into OPA
+  sync:
+    syncOnly:
+      - group: "apps"
+        version: "v1"
+        kind: "Deployment"
+      - group: "extensions"
+        version: "v1beta1"
+        kind: "Deployment"

--- a/katalog/opa-gatekeeper/constraints/kustomization.yaml
+++ b/katalog/opa-gatekeeper/constraints/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- requiredImageTagTemplate.yml
+- requiredLimitsTemplate.yml
+- requiredImageTag.yml
+- requiredLimits.yml

--- a/katalog/opa-gatekeeper/constraints/requiredImageTag.yml
+++ b/katalog/opa-gatekeeper/constraints/requiredImageTag.yml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredImageTag
+metadata:
+  name: deployments-must-have-image-tag
+spec:
+  match:
+    kinds:
+      - apiGroups: ["apps", "extensions"]
+        kinds: ["Deployment"]      

--- a/katalog/opa-gatekeeper/constraints/requiredImageTagTemplate.yml
+++ b/katalog/opa-gatekeeper/constraints/requiredImageTagTemplate.yml
@@ -1,0 +1,30 @@
+##
+## CHECK LATEST TAG NOT USED
+##
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredimagetag
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredImageTag
+        listKind: K8sRequiredImageTagList
+        plural: k8srequiredimagetag
+        singular: k8srequiredimagetag
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredimagetag
+
+        check_resources(image) {
+          not endswith(image, ":latest")
+          contains(image, ":")
+        }
+
+        violation[{"msg": msg}] {
+          image := input.review.object.spec.template.spec[_][_].image
+          not check_resources(image)
+          msg := sprintf("image %s using latest tag", [image])
+        }

--- a/katalog/opa-gatekeeper/constraints/requiredLimits.yml
+++ b/katalog/opa-gatekeeper/constraints/requiredLimits.yml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLimits
+metadata:
+  name: deployments-must-have-limits
+spec:
+  match:
+    kinds:
+      - apiGroups: ["apps", "extensions"]
+        kinds: ["Deployment"]      

--- a/katalog/opa-gatekeeper/constraints/requiredLimitsTemplate.yml
+++ b/katalog/opa-gatekeeper/constraints/requiredLimitsTemplate.yml
@@ -1,0 +1,32 @@
+##
+## CHECK REQUESTS AND LIMITS ARE SET
+##
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredlimits
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredLimits
+        listKind: K8sRequiredLimitsList
+        plural: k8srequiredlimits
+        singular: k8srequiredlimits
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredlimits
+
+        check_resources(object) {
+          count({x | object.spec[_][x].resources["limits"].cpu; object.spec[_][x].resources["limits"].memory}) == count(object.spec.containers)
+        } else {
+          count({x | object.spec.template.spec[_][x].resources["limits"].cpu; object.spec.template.spec[_][x].resources["limits"].memory}) == count(object.spec.template.spec.containers)
+        }
+
+        violation[{"msg": msg}] {
+          object := input.review.object
+          not check_resources(object)
+          msg := "Limits are not set"
+        }
+

--- a/katalog/opa-gatekeeper/crd.yml
+++ b/katalog/opa-gatekeeper/crd.yml
@@ -1,0 +1,200 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: configs.config.gatekeeper.sh
+spec:
+  group: config.gatekeeper.sh
+  names:
+    kind: Config
+    plural: configs
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            sync:
+              description: Configuration for syncing k8s objects
+              properties:
+                syncOnly:
+                  description: If non-empty, only entries on this list will be replicated
+                    into OPA
+                  items:
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            validation:
+              description: Configuration for validation
+              properties:
+                traces:
+                  description: List of requests to trace. Both "user" and "kinds"
+                    must be specified
+                  items:
+                    properties:
+                      dump:
+                        description: Also dump the state of OPA with the trace. Set
+                          to `All` to dump everything.
+                        type: string
+                      kind:
+                        description: Only trace requests of the following GroupVersionKind
+                        properties:
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          version:
+                            type: string
+                        type: object
+                      user:
+                        description: Only trace requests from the specified user
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          properties:
+            byPod:
+              description: List of statuses as seen by individual pods
+              items:
+                properties:
+                  allFinalizers:
+                    description: List of Group/Version/Kinds with finalizers
+                    items:
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    type: array
+                  id:
+                    description: a unique identifier for the pod that wrote the status
+                    type: string
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: constrainttemplates.templates.gatekeeper.sh
+spec:
+  group: templates.gatekeeper.sh
+  names:
+    kind: ConstraintTemplate
+    plural: constrainttemplates
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            crd:
+              properties:
+                spec:
+                  properties:
+                    names:
+                      properties:
+                        kind:
+                          type: string
+                      type: object
+                    validation:
+                      type: object
+                  type: object
+              type: object
+            targets:
+              items:
+                properties:
+                  rego:
+                    type: string
+                  target:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            byPod:
+              items:
+                properties:
+                  errors:
+                    items:
+                      properties:
+                        code:
+                          type: string
+                        location:
+                          type: string
+                        message:
+                          type: string
+                      required:
+                      - code
+                      - message
+                      type: object
+                    type: array
+                  id:
+                    description: a unique identifier for the pod that wrote the status
+                    type: string
+                type: object
+              type: array
+            created:
+              type: boolean
+          type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/katalog/opa-gatekeeper/deploy.yml
+++ b/katalog/opa-gatekeeper/deploy.yml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: gatekeeper-controller-manager
+  namespace: gatekeeper-system
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  serviceName: gatekeeper-controller-manager-service
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - args:
+        - --auditInterval=30
+        - --port=8443
+        - --log-level=DEBUG
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SECRET_NAME
+          value: gatekeeper-webhook-server-secret
+        image: quay.io/open-policy-agent/gatekeeper:v3.0.4-beta.2
+        imagePullPolicy: Always
+        name: manager
+        ports:
+        - containerPort: 8443
+          name: webhook-server
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: gatekeeper-webhook-server-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: gatekeeper-controller-manager-service
+  namespace: gatekeeper-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"

--- a/katalog/opa-gatekeeper/kustomization.yaml
+++ b/katalog/opa-gatekeeper/kustomization.yaml
@@ -1,0 +1,10 @@
+namespace: gatekeeper-system
+
+resources:
+- ns.yml
+- secret.yml
+- rbac.yml
+- crd.yml
+- deploy.yml
+- audit.yml
+

--- a/katalog/opa-gatekeeper/ns.yml
+++ b/katalog/opa-gatekeeper/ns.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: gatekeeper-system

--- a/katalog/opa-gatekeeper/rbac.yml
+++ b/katalog/opa-gatekeeper/rbac.yml
@@ -1,0 +1,161 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gatekeeper-manager-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - config.gatekeeper.sh
+  resources:
+  - configs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - config.gatekeeper.sh
+  resources:
+  - configs/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gatekeeper-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gatekeeper-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: gatekeeper-system

--- a/katalog/opa-gatekeeper/secret.yml
+++ b/katalog/opa-gatekeeper/secret.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gatekeeper-webhook-server-secret
+type: Opaque


### PR DESCRIPTION
Following the [official guide](https://github.com/open-policy-agent/gatekeeper) I have created the Fury module to deploy Gatekeeper on Kubernetes.

I have configured the `Audit` function for Deployment objects. This function allows administrators to check which are the objects already present in the cluster that are violating policies.

In folder `Constraints` there are 2 examples of policy constraints always based on Deployment objects:

1. **k8srequiredimagetag**: verifies that Deployments don't use latest tag in images
1. **k8srequiredlimits**:  verifies that Deployments have limits specified