### PR TITLE
Fixed enforcementAction typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ specific dependencies please visit the single package's documentation:
 | Module Version / Kubernetes Version |       1.14.X       |       1.15.X       |       1.16.X       |
 | ----------------------------------- | :----------------: | :----------------: | :----------------: |
 | v1.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.0.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 ## License
 

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -1,0 +1,8 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.0.0` and this release: `1.0.1`
+
+- FIX: constraint `enforcementaction` typo: `enforcementAction`. This didn't get caught before because deny is the
+  default enforcement action for constraints: https://github.com/sighupio/fury-kubernetes-opa/pull/3

--- a/katalog/gatekeeper/rules/constraints/must_have_liveness_probe.yml
+++ b/katalog/gatekeeper/rules/constraints/must_have_liveness_probe.yml
@@ -4,4 +4,4 @@ kind: K8sLivenessProbe
 metadata:
   name: liveness-probe
 spec:
-  enforcementaction: deny
+  enforcementAction: deny

--- a/katalog/gatekeeper/rules/constraints/must_have_readiness_probe.yml
+++ b/katalog/gatekeeper/rules/constraints/must_have_readiness_probe.yml
@@ -4,4 +4,4 @@ kind: K8sReadinessProbe
 metadata:
   name: readiness-probe
 spec:
-  enforcementaction: deny
+  enforcementAction: deny

--- a/katalog/gatekeeper/rules/constraints/must_have_unique_service_selector.yml
+++ b/katalog/gatekeeper/rules/constraints/must_have_unique_service_selector.yml
@@ -4,4 +4,4 @@ kind: K8sUniqueServiceSelector
 metadata:
   name: unique-service-selector
 spec:
-  enforcementaction: deny
+  enforcementAction: deny


### PR DESCRIPTION
If you change `enforcementaction` to `dryrun` nothing happens, because the correct form is `enforcementAction` with the capital A. This didn't get caught before because `deny` is the default enforcement action for constraints.