### PR TITLE
Prometheus Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ Kubernetes Cluster.
 
 The following packages are included in Fury Kubernetes OPA module:
 
--   [Gatekeeper](katalog/gatekeeper): Ready to use gatekeeper deployment plus a set of rules. Version: **v3.1.0-beta.8**
-    -   [Gatekeeper Core](katalog/gatekeeper/core): Gatekeeper deployment, ready to apply rules. Version: **v3.1.0-beta.8**
-    -   [Gatekeeper Rules](katalog/gatekeeper/rules): Gatekeeper rules:
-        -   deny of docker images with latest tag
-        -   deny of pods that have no limit declared (both cpu and memory)
-        -   deny of pods that allow privilege escalation explicitly
-        -   deny of pods that run as root
-        -   deny of pods that doesn't declare livenessProbe and readinessProbe
-        -   deny of duplicated ingresses
+- [Gatekeeper](katalog/gatekeeper): Ready to use gatekeeper deployment plus a set of rules. Version: **v3.1.0-beta.8**
+  - [Gatekeeper Core](katalog/gatekeeper/core): Gatekeeper deployment, ready to apply rules. Version: **v3.1.0-beta.8**
+  - [Gatekeeper Rules](katalog/gatekeeper/rules): Gatekeeper rules:
+    - deny of docker images with latest tag
+    - deny of pods that have no limit declared (both cpu and memory)
+    - deny of pods that allow privilege escalation explicitly
+    - deny of pods that run as root
+    - deny of pods that doesn't declare livenessProbe and readinessProbe
+    - deny of duplicated ingresses
 
 You can click on each package to see its documentation.
 
@@ -24,10 +24,13 @@ You can click on each package to see its documentation.
 All packages in this repository have following dependencies, for package
 specific dependencies please visit the single package's documentation:
 
--   [Kubernetes](https://kubernetes.io) >= `v1.14.0`
--   [Furyctl](https://github.com/sighupio/furyctl) package manager to download
+- [Kubernetes](https://kubernetes.io) >= `v1.14.0`
+- [Furyctl](https://github.com/sighupio/furyctl) package manager to download
     Fury packages >= [`v0.2.2`](https://github.com/sighupio/furyctl/releases/tag/v0.2.2)
--   [Kustomize](https://github.com/kubernetes-sigs/kustomize) = `v3.3.0`
+- [Kustomize](https://github.com/kubernetes-sigs/kustomize) = `v3.3.0`
+- [prometheus-operator](https://github.com/sighupio/fury-kubernetes-monitoring/tree/master/katalog/prometheus-operator) from the [Fury Monitoring Module](https://github.com/sighupio/fury-kubernetes-monitoring) is required by [Service monitor](./katalog/gatekeeper/core/service-monitor.yml) to export metrics to Prometheus.
+
+> You can comment out the service monitor in the [kustomization.yaml](./katalog/gatekeeper/core/kustomization.yaml) file if you don't want to install the monitoring module.
 
 ## Compatibility
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,8 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.0.2` and this release: `TBD`
+
+- Add metrics port to service
+- Add service monitor definition for Prometheus scarping

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,3 +6,4 @@ Changes between `1.0.2` and this release: `TBD`
 
 - Add metrics port to service
 - Add service monitor definition for Prometheus scarping
+- [prometheus-operator](https://github.com/sighupio/fury-kubernetes-monitoring/tree/master/katalog/prometheus-operator) from the [Fury Monitoring Module](https://github.com/sighupio/fury-kubernetes-monitoring) is now required by [Service monitor](./katalog/gatekeeper/core/service-monitor.yml) to export metrics to Prometheus (it can be disabled).

--- a/katalog/gatekeeper/core/kustomization.yaml
+++ b/katalog/gatekeeper/core/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - deploy.yml
   - svc.yml
   - vwh.yml
+  - service-monitor.yml

--- a/katalog/gatekeeper/core/service-monitor.yml
+++ b/katalog/gatekeeper/core/service-monitor.yml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gatekeeper
+  labels:
+    gatekeeper.sh/system: "yes"
+spec:
+  endpoints:
+    - interval: 10s
+      port: metrics
+      scheme: http
+      path: /metrics
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+      - gatekeeper-system
+  selector:
+    matchLabels:
+      gatekeeper.sh/system: "yes"

--- a/katalog/gatekeeper/core/svc.yml
+++ b/katalog/gatekeeper/core/svc.yml
@@ -9,7 +9,7 @@ spec:
   ports:
     - port: 443
       targetPort: 8443
-      name: gwebhook-service
+      name: webhook-server
     - port: 8888
       targetPort: 8888
       name: metrics

--- a/katalog/gatekeeper/core/svc.yml
+++ b/katalog/gatekeeper/core/svc.yml
@@ -9,6 +9,10 @@ spec:
   ports:
     - port: 443
       targetPort: 8443
+      name: gwebhook-service
+    - port: 8888
+      targetPort: 8888
+      name: metrics
   selector:
     control-plane: controller-manager
     gatekeeper.sh/system: "yes"


### PR DESCRIPTION
Hello team!

This PR adds the metrics port to the service definition and the service monitor definition for prometheus scraping in order to be able to see Gatekeeper metrics on a Grafana Dashboard