### PR TITLE
Disable High Availability

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -7,3 +7,4 @@ Changes between `1.0.2` and this release: `TBD`
 - Add metrics port to service
 - Add service monitor definition for Prometheus scarping
 - [prometheus-operator](https://github.com/sighupio/fury-kubernetes-monitoring/tree/master/katalog/prometheus-operator) from the [Fury Monitoring Module](https://github.com/sighupio/fury-kubernetes-monitoring) is now required by [Service monitor](./katalog/gatekeeper/core/service-monitor.yml) to export metrics to Prometheus (it can be disabled).
+- Set default replica count to 1 due to HA not being supported upstream

--- a/katalog/gatekeeper/core/deploy.yml
+++ b/katalog/gatekeeper/core/deploy.yml
@@ -7,7 +7,7 @@ metadata:
     gatekeeper.sh/system: "yes"
   name: gatekeeper-controller-manager
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
Hi team!

As discussed, I'm opening this PR to disable the deployment in HA by default. According to upstream this feature is not yet fully supported.

From the README upstream:
> We are currently working on addressing issues that may cause multi-pod deployments of Gatekeeper to not work as expected.

References:
https://github.com/open-policy-agent/gatekeeper#admission-webhook-fail-open-status
https://github.com/open-policy-agent/gatekeeper/issues/671
https://github.com/open-policy-agent/gatekeeper/issues/348
https://github.com/open-policy-agent/gatekeeper/issues?q=is%3Aopen+is%3Aissue+label%3A%22Fail+Closed%22
