### PR TITLE
Adds OPA rules regarding host and root limitations

### DIFF
--- a/katalog/gatekeeper/rules/constraints/kustomization.yaml
+++ b/katalog/gatekeeper/rules/constraints/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - must_have_unique_ingresses.yml
   - must_have_liveness_probe.yml
   - must_have_readiness_probe.yml
+  - must_not_escalate.yml
+  - must_not_have_capabilities.yml
+  - must_not_have_host_namespaces.yml
+  - must_not_have_host_network_ports.yml
+  - must_not_have_host_path.yml
+  - must_not_have_root.yml
 
 patchesJson6902:
   - target:
@@ -31,4 +37,40 @@ patchesJson6902:
       version: v1beta1
       kind: K8sReadinessProbe
       name: readiness-probe
+    path: patches/all-matches.yml
+  - target:
+      group: constraints.gatekeeper.sh
+      version: v1beta1
+      kind: K8sPSPAllowPrivilegeEscalationContainer
+      name: disallow-escalation
+    path: patches/all-matches.yml
+  - target:
+      group: constraints.gatekeeper.sh
+      version: v1beta1
+      kind: K8sPSPCapabilities
+      name: disallow-capabilities
+    path: patches/all-matches.yml
+  - target:
+      group: constraints.gatekeeper.sh
+      version: v1beta1
+      kind: K8sPSPHostNamespace
+      name: disallow-host-namespace
+    path: patches/all-matches.yml
+  - target:
+      group: constraints.gatekeeper.sh
+      version: v1beta1
+      kind: K8sPSPHostNetworkingPorts
+      name: disallow-host-network-ports
+    path: patches/all-matches.yml
+  - target:
+      group: constraints.gatekeeper.sh
+      version: v1beta1
+      kind: K8sPSPHostFilesystem
+      name: disallow-host-filesystem
+    path: patches/all-matches.yml
+  - target:
+      group: constraints.gatekeeper.sh
+      version: v1beta1
+      kind: K8sPSPAllowedUsers
+      name: disallow-root
     path: patches/all-matches.yml

--- a/katalog/gatekeeper/rules/constraints/must_not_escalate.yml
+++ b/katalog/gatekeeper/rules/constraints/must_not_escalate.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPAllowPrivilegeEscalationContainer
+metadata:
+  name: disallow-escalation
+spec:
+  enforcementAction: deny

--- a/katalog/gatekeeper/rules/constraints/must_not_have_capabilities.yml
+++ b/katalog/gatekeeper/rules/constraints/must_not_have_capabilities.yml
@@ -1,0 +1,8 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPCapabilities
+metadata:
+  name: disallow-capabilities
+spec:
+  parameters:
+    allowedCapabilities: []
+    requiredDropCapabilities: ["ALL"]

--- a/katalog/gatekeeper/rules/constraints/must_not_have_host_namespaces.yml
+++ b/katalog/gatekeeper/rules/constraints/must_not_have_host_namespaces.yml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostNamespace
+metadata:
+  name: disallow-host-namespace
+spec:
+  match:
+    kinds:
+      - apiGroups: []
+        kinds: []

--- a/katalog/gatekeeper/rules/constraints/must_not_have_host_network_ports.yml
+++ b/katalog/gatekeeper/rules/constraints/must_not_have_host_network_ports.yml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostNetworkingPorts
+metadata:
+  name: disallow-host-network-ports
+spec:
+  enforcementAction: deny
+  parameters:
+    hostNetwork: false
+    min: 0
+    max: 900000

--- a/katalog/gatekeeper/rules/constraints/must_not_have_host_path.yml
+++ b/katalog/gatekeeper/rules/constraints/must_not_have_host_path.yml
@@ -1,0 +1,8 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostFilesystem
+metadata:
+  name: disallow-host-filesystem
+spec:
+  enforcementAction: deny
+  parameters:
+    allowedHostPaths: []

--- a/katalog/gatekeeper/rules/constraints/must_not_have_root.yml
+++ b/katalog/gatekeeper/rules/constraints/must_not_have_root.yml
@@ -1,0 +1,8 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPAllowedUsers
+metadata:
+  name: disallow-root
+spec:
+  parameters:
+    runAsUser:
+      rule: MustRunAsNonRoot # MustRunAsNonRoot # RunAsAny #MustRunAs

--- a/katalog/gatekeeper/rules/templates/capabilities_template.yml
+++ b/katalog/gatekeeper/rules/templates/capabilities_template.yml
@@ -1,0 +1,64 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspcapabilities
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPCapabilities
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedCapabilities:
+              type: array
+              items:
+                type: string
+            requiredDropCapabilities:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package capabilities
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.containers[_]
+          has_disallowed_capabilities(container)
+          msg := sprintf("container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "allowedCapabilities", "NONE")])
+        }
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.containers[_]
+          missing_drop_capabilities(container)
+          msg := sprintf("container <%v> is not dropping all required capabilities. Container must drop all of %v", [container.name, input.parameters.requiredDropCapabilities])
+        }
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.initContainers[_]
+          has_disallowed_capabilities(container)
+          msg := sprintf("init container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "allowedCapabilities", "NONE")])
+        }
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.initContainers[_]
+          missing_drop_capabilities(container)
+          msg := sprintf("init container <%v> is not dropping all required capabilities. Container must drop all of %v", [container.name, input.parameters.requiredDropCapabilities])
+        }
+        has_disallowed_capabilities(container) {
+          allowed := {c | c := input.parameters.allowedCapabilities[_]}
+          not allowed["*"]
+          capabilities := {c | c := container.securityContext.capabilities.add[_]}
+          count(capabilities - allowed) > 0
+        }
+        missing_drop_capabilities(container) {
+          must_drop := {c | c := input.parameters.requiredDropCapabilities[_]}
+          dropped := {c | c := container.securityContext.capabilities.drop[_]}
+          count(must_drop - dropped) > 0
+        }
+        get_default(obj, param, _default) = out {
+          out = obj[param]
+        }
+        get_default(obj, param, _default) = out {
+          not obj[param]
+          not obj[param] == false
+          out = _default
+        }

--- a/katalog/gatekeeper/rules/templates/container_privilege_escalation_template.yml
+++ b/katalog/gatekeeper/rules/templates/container_privilege_escalation_template.yml
@@ -1,0 +1,34 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspallowprivilegeescalationcontainer
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPAllowPrivilegeEscalationContainer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8spspallowprivilegeescalationcontainer
+        violation[{"msg": msg, "details": {}}] {
+            c := input_containers[_]
+            input_allow_privilege_escalation(c)
+            msg := sprintf("Privilege escalation container is not allowed: %v", [c.name])
+        }
+        input_allow_privilege_escalation(c) {
+            not has_field(c, "securityContext")
+        }
+        input_allow_privilege_escalation(c) {
+            not c.securityContext.allowPrivilegeEscalation == false
+        }
+        input_containers[c] {
+            c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+            c := input.review.object.spec.initContainers[_]
+        }
+        # has_field returns whether an object has a field
+        has_field(object, field) = true {
+            object[field]
+        }

--- a/katalog/gatekeeper/rules/templates/host_namespaces_template.yml
+++ b/katalog/gatekeeper/rules/templates/host_namespaces_template.yml
@@ -1,0 +1,23 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8spsphostnamespace
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPHostNamespace
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8spsphostnamespace
+        violation[{"msg": msg, "details": {}}] {
+            input_share_hostnamespace(input.review.object)
+            msg := sprintf("Sharing the host namespace is not allowed: %v", [input.review.object.metadata.name])
+        }
+        input_share_hostnamespace(o) {
+            o.spec.hostPID
+        }
+        input_share_hostnamespace(o) {
+            o.spec.hostIPC
+        }

--- a/katalog/gatekeeper/rules/templates/host_network_ports_template.yml
+++ b/katalog/gatekeeper/rules/templates/host_network_ports_template.yml
@@ -1,0 +1,46 @@
+
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8spsphostnetworkingports
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPHostNetworkingPorts
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            hostNetwork:
+              type: boolean
+            min:
+              type: integer
+            max:
+              type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8spsphostnetworkingports
+        violation[{"msg": msg, "details": {}}] {
+          input_share_hostnetwork(input.review.object)
+          msg := sprintf("The specified hostNetwork and hostPort are not allowed, pod: %v. Allowed values: %v", [input.review.object.metadata.name, input.parameters])
+        }
+        input_share_hostnetwork(o) {
+          not input.parameters.hostNetwork
+          o.spec.hostNetwork
+        }
+        input_share_hostnetwork(o) {
+          hostPort := input_containers[_].ports[_].hostPort
+          hostPort < input.parameters.min
+        }
+        input_share_hostnetwork(o) {
+          hostPort := input_containers[_].ports[_].hostPort
+          hostPort > input.parameters.max
+        }
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }

--- a/katalog/gatekeeper/rules/templates/host_path_template.yml
+++ b/katalog/gatekeeper/rules/templates/host_path_template.yml
@@ -1,0 +1,96 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8spsphostfilesystem
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPHostFilesystem
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            allowedHostPaths:
+              type: array
+              items:
+                type: object
+                properties:
+                  readOnly:
+                    type: boolean
+                  pathPrefix:
+                    type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8spsphostfilesystem
+        violation[{"msg": msg, "details": {}}] {
+            volume := input_hostpath_volumes[_]
+            allowedPaths := get_allowed_paths(input)
+            input_hostpath_violation(allowedPaths, volume)
+            msg := sprintf("HostPath volume %v is not allowed, pod: %v. Allowed path: %v", [volume, input.review.object.metadata.name, allowedPaths])
+        }
+        input_hostpath_violation(allowedPaths, volume) {
+            # An empty list means all host paths are blocked
+            allowedPaths == []
+        }
+        input_hostpath_violation(allowedPaths, volume) {
+            not input_hostpath_allowed(allowedPaths, volume)
+        }
+        get_allowed_paths(arg) = out {
+            not arg.parameters
+            out = []
+        }
+        get_allowed_paths(arg) = out {
+            not arg.parameters.allowedHostPaths
+            out = []
+        }
+        get_allowed_paths(arg) = out {
+            out = arg.parameters.allowedHostPaths
+        }
+        input_hostpath_allowed(allowedPaths, volume) {
+            allowedHostPath := allowedPaths[_]
+            path_matches(allowedHostPath.pathPrefix, volume.hostPath.path)
+            not allowedHostPath.readOnly == true
+        }
+        input_hostpath_allowed(allowedPaths, volume) {
+            allowedHostPath := allowedPaths[_]
+            path_matches(allowedHostPath.pathPrefix, volume.hostPath.path)
+            allowedHostPath.readOnly
+            not writeable_input_volume_mounts(volume.name)
+        }
+        writeable_input_volume_mounts(volume_name) {
+            container := input_containers[_]
+            mount := container.volumeMounts[_]
+            mount.name == volume_name
+            not mount.readOnly
+        }
+        # This allows "/foo", "/foo/", "/foo/bar" etc., but
+        # disallows "/fool", "/etc/foo" etc.
+        path_matches(prefix, path) {
+            a := split(trim(prefix, "/"), "/")
+            b := split(trim(path, "/"), "/")
+            prefix_matches(a, b)
+        }
+        prefix_matches(a, b) {
+            count(a) <= count(b)
+            not any_not_equal_upto(a, b, count(a))
+        }
+        any_not_equal_upto(a, b, n) {
+            a[i] != b[i]
+            i < n
+        }
+        input_hostpath_volumes[v] {
+            v := input.review.object.spec.volumes[_]
+            has_field(v, "hostPath")
+        }
+        # has_field returns whether an object has a field
+        has_field(object, field) = true {
+            object[field]
+        }
+        input_containers[c] {
+            c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+            c := input.review.object.spec.initContainers[_]
+        }

--- a/katalog/gatekeeper/rules/templates/kustomization.yaml
+++ b/katalog/gatekeeper/rules/templates/kustomization.yaml
@@ -6,3 +6,9 @@ resources:
   - unique_ingress_template.yml
   - livenessprobe_template.yml
   - readinessproble_template.yml
+  - capabilities_template.yml
+  - container_privilege_escalation_template.yml
+  - host_namespaces_template.yml
+  - host_network_ports_template.yml
+  - host_path_template.yml
+  - users_template.yml

--- a/katalog/gatekeeper/rules/templates/users_template.yml
+++ b/katalog/gatekeeper/rules/templates/users_template.yml
@@ -1,0 +1,157 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspallowedusers
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPAllowedUsers
+      validation:
+        openAPIV3Schema:
+          properties:
+            runAsUser:
+              type: object
+              properties:
+                rule:
+                  type: string
+                ranges:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      min:
+                        type: integer
+                      max:
+                        type: integer
+            runAsGroup:
+              type: object
+              properties:
+                rule:
+                  type: string
+                ranges:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      min:
+                        type: integer
+                      max:
+                        type: integer
+            supplementalGroups:
+              type: object
+              properties:
+                rule:
+                  type: string
+                ranges:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      min:
+                        type: integer
+                      max:
+                        type: integer
+            fsGroup:
+              type: object
+              properties:
+                rule:
+                  type: string
+                ranges:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      min:
+                        type: integer
+                      max:
+                        type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8spspallowedusers
+        violation[{"msg": msg}] {
+          fields := ["runAsUser", "runAsGroup", "supplementalGroups", "fsGroup"]
+          field := fields[_]
+          container := input_containers[_]
+          msg := get_type_violation(field, container)
+        }
+        get_type_violation(field, container) = msg {
+          field == "runAsUser"
+          params := input.parameters[field]
+          msg := get_user_violation(params, container)
+        }
+        get_type_violation(field, container) = msg {
+          field != "runAsUser"
+          params := input.parameters[field]
+          msg := get_violation(field, params, container)
+        }
+        # RunAsUser (separate due to "MustRunAsNonRoot")
+        get_user_violation(params, container) = msg {
+          rule := params.rule
+          provided_user := get_field_value("runAsUser", container, input.review)
+          not accept_users(rule, provided_user)
+          msg := sprintf("Container %v is attempting to run as disallowed user %v. Allowed runAsUser: %v", [container.name, provided_user, params])
+        }
+        get_user_violation(params, container) = msg {
+          not get_field_value("runAsUser", container, input.review)
+          params.rule != "RunAsAny"
+          msg := sprintf("Container %v is attempting to run without a required securityContext/runAsUser. Allowed runAsUser: %v", [container.name, params])
+        }
+        accept_users("RunAsAny", provided_user) {true}
+        accept_users("MustRunAsNonRoot", provided_user) = res {res := provided_user != 0}
+        accept_users("MustRunAs", provided_user) = res  {
+          ranges := input.parameters.runAsUser.ranges
+          res := is_in_range(provided_user, ranges)
+        }
+        # Group Options
+        get_violation(field, params, container) = msg {
+          rule := params.rule
+          provided_value := get_field_value(field, container, input.review)
+          not is_array(provided_value)
+          not accept_value(rule, provided_value, params.ranges)
+          msg := sprintf("Container %v is attempting to run as disallowed group %v. Allowed %v: %v", [container.name, provided_value, field, params])
+        }
+        # SupplementalGroups is array value
+        get_violation(field, params, container) = msg {
+          rule := params.rule
+          array_value := get_field_value(field, container, input.review)
+          is_array(array_value)
+          provided_value := array_value[_]
+          not accept_value(rule, provided_value, params.ranges)
+          msg := sprintf("Container %v is attempting to run with disallowed supplementalGroups %v. Allowed %v: %v", [container.name, array_value, field, params])
+        }
+        get_violation(field, params, container) = msg {
+          not get_field_value(field, container, input.review)
+          params.rule == "MustRunAs"
+          msg := sprintf("Container %v is attempting to run without a required securityContext/%v. Allowed %v: %v", [container.name, field, field, params])
+        }
+        accept_value("RunAsAny", provided_value, ranges) {true}
+        accept_value("MayRunAs", provided_value, ranges) = res { res := is_in_range(provided_value, ranges)}
+        accept_value("MustRunAs", provided_value, ranges) = res { res := is_in_range(provided_value, ranges)}
+        # If container level is provided, that takes precedence
+        get_field_value(field, container, review) = out {
+          container_value := get_seccontext_field(field, container)
+          out := container_value
+        }
+        # If no container level exists, use pod level
+        get_field_value(field, container, review) = out {
+          not get_seccontext_field(field, container)
+          review.kind.kind == "Pod"
+          pod_value := get_seccontext_field(field, review.object.spec)
+          out := pod_value
+        }
+        # Helper Functions
+        is_in_range(val, ranges) = res {
+          matching := {1 | val >= ranges[j].min; val <= ranges[j].max}
+          res := count(matching) > 0
+        }
+        get_seccontext_field(field, obj) = out {
+          out = obj.securityContext[field]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }


### PR DESCRIPTION
This PR aims to integrate several more rules to Fury OPA, taken from: https://github.com/open-policy-agent/gatekeeper/tree/master/library/pod-security-policy/

It is marked as a DRAFT because:

- those additional rules may not be needed
- it could require some different architecture/naming conventions to the files added

