### PR TITLE
FIX: Add exclude istio flag

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,19 @@
+# OPA Core Module version TBD
+
+TBD
+
+## Changelog
+
+- Adds `excludeIstio` flag to:
+  - `K8sLivenessProbe`
+  - `K8sReadinessProbe`
+  - `SecurityControls`
+
+## Upgrade path
+
+To upgrade this core module from `v1.2.1`, you need to download this new version, then apply the
+`kustomize` project. No further action is required.
+
+```bash
+kustomize build katalog/gatekeeper | kubectl apply -f - --force
+```

--- a/katalog/gatekeeper/rules/constraints/must_have_liveness_probe.yml
+++ b/katalog/gatekeeper/rules/constraints/must_have_liveness_probe.yml
@@ -9,3 +9,5 @@ metadata:
   name: liveness-probe
 spec:
   enforcementAction: deny
+  parameters:
+    excludeIstio: false

--- a/katalog/gatekeeper/rules/constraints/must_have_readiness_probe.yml
+++ b/katalog/gatekeeper/rules/constraints/must_have_readiness_probe.yml
@@ -9,3 +9,5 @@ metadata:
   name: readiness-probe
 spec:
   enforcementAction: deny
+  parameters:
+    excludeIstio: false

--- a/katalog/gatekeeper/rules/constraints/must_have_security_controls.yml
+++ b/katalog/gatekeeper/rules/constraints/must_have_security_controls.yml
@@ -9,3 +9,5 @@ metadata:
   name: enforce-deployment-and-pod-security-controls
 spec:
   enforcementAction: deny
+  parameters:
+    excludeIstio: false

--- a/katalog/gatekeeper/rules/templates/livenessprobe_template.yml
+++ b/katalog/gatekeeper/rules/templates/livenessprobe_template.yml
@@ -15,6 +15,11 @@ spec:
         listKind: K8sLivenessProbeList
         plural: k8slivenessprobe
         singular: k8slivenessprobe
+      validation:
+        openAPIV3Schema:
+          properties:
+            excludeIstio:
+              type: boolean # Default is false
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
@@ -24,6 +29,7 @@ spec:
             name := input.review.object.metadata.name
             kind := input.review.kind.kind
             not containers.livenessProbe
+            not input.parameters.excludeIstio
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -31,6 +37,7 @@ spec:
             name := input.review.object.metadata.name
             kind := input.review.kind.kind
             not containers.livenessProbe
+            not input.parameters.excludeIstio
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -38,5 +45,40 @@ spec:
             name := input.review.object.metadata.name
             kind := input.review.kind.kind
             not containers.livenessProbe
+            not input.parameters.excludeIstio
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
+        }
+
+        violation[{"msg": msg}] {
+            containers := input.review.object.spec.template.spec.containers[_]
+            name := input.review.object.metadata.name
+            kind := input.review.kind.kind
+            not containers.livenessProbe
+            input.parameters.excludeIstio
+            not istio(containers.image)
+            msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
+        }
+
+        violation[{"msg": msg}] {
+            containers := input.review.object.spec.containers[_]
+            name := input.review.object.metadata.name
+            kind := input.review.kind.kind
+            not containers.livenessProbe
+            input.parameters.excludeIstio
+            not istio(containers.image)
+            msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
+        }
+
+        violation[{"msg": msg}] {
+            containers := input.review.object.spec.jobTemplate.spec.template.spec.containers[_]
+            name := input.review.object.metadata.name
+            kind := input.review.kind.kind
+            not containers.livenessProbe
+            input.parameters.excludeIstio
+            not istio(containers.image)
+            msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
+        }
+
+        istio(image) {
+          contains(image, "istio/proxyv2")
         }

--- a/katalog/gatekeeper/rules/templates/readinessproble_template.yml
+++ b/katalog/gatekeeper/rules/templates/readinessproble_template.yml
@@ -15,6 +15,11 @@ spec:
         listKind: K8sReadinessProbeList
         plural: k8sreadinessprobe
         singular: k8sreadinessprobe
+      validation:
+        openAPIV3Schema:
+          properties:
+            excludeIstio:
+              type: boolean # Default is false
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
@@ -24,6 +29,7 @@ spec:
             name := input.review.object.metadata.name
             kind := input.review.kind.kind
             not containers.readinessProbe
+            not input.parameters.excludeIstio
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -31,6 +37,7 @@ spec:
             name := input.review.object.metadata.name
             kind := input.review.kind.kind
             not containers.readinessProbe
+            not input.parameters.excludeIstio
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -38,5 +45,38 @@ spec:
             name := input.review.object.metadata.name
             kind := input.review.kind.kind
             not containers.readinessProbe
+            not input.parameters.excludeIstio
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
+        }
+
+        violation[{"msg": msg}] {
+            containers := input.review.object.spec.template.spec.containers[_]
+            name := input.review.object.metadata.name
+            kind := input.review.kind.kind
+            not containers.readinessProbe
+            input.parameters.excludeIstio
+            not istio(containers.image)
+            msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
+        }
+        violation[{"msg": msg}] {
+            containers := input.review.object.spec.containers[_]
+            name := input.review.object.metadata.name
+            kind := input.review.kind.kind
+            not containers.readinessProbe
+            input.parameters.excludeIstio
+            not istio(containers.image)
+            msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
+        }
+        violation[{"msg": msg}] {
+            containers := input.review.object.spec.jobTemplate.spec.template.spec.containers[_]
+            name := input.review.object.metadata.name
+            kind := input.review.kind.kind
+            not containers.readinessProbe
+            input.parameters.excludeIstio
+            not istio(containers.image)
+            msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
+        }
+
+        istio(image) {
+          contains(image, "istio/proxyv2")
         }

--- a/katalog/gatekeeper/rules/templates/security_controls_template.yml
+++ b/katalog/gatekeeper/rules/templates/security_controls_template.yml
@@ -14,6 +14,11 @@ spec:
         listKind: SecurityControlsList
         plural: securitycontrols
         singular: securitycontrol
+      validation:
+        openAPIV3Schema:
+          properties:
+            excludeIstio:
+              type: boolean # Default is false
   targets:
     - libs:
         - |
@@ -101,37 +106,95 @@ spec:
                   has_field(c, "securityContext")
                   has_field(c.securityContext, "allowPrivilegeEscalation")
           }
+
       rego: |
         package main
         import data.lib.kubernetes
+
+        istio(image) {
+                contains(image, "istio/proxyv2")
+        }
+
+        # Latests
         violation[msg] {
                 kubernetes.containers[container]
                 [image_name, "latest"] = kubernetes.split_image(container.image)
+                not input.parameters.excludeIstio
                 msg = kubernetes.format(sprintf("%s in the %s %s has an image, %s, using the latest tag", [container.name, kubernetes.kind, image_name, kubernetes.name]))
         }
+        # ISTIO: Latests
+        violation[msg] {
+                kubernetes.containers[container]
+                [image_name, "latest"] = kubernetes.split_image(container.image)
+                input.parameters.excludeIstio
+                not istio(container.image)
+                msg = kubernetes.format(sprintf("%s in the %s %s has an image, %s, using the latest tag", [container.name, kubernetes.kind, image_name, kubernetes.name]))
+        }
+
         # https://kubesec.io/basics/containers-resources-limits-memory
         violation[msg] {
                 kubernetes.containers[container]
                 not container.resources.limits.memory
+                not input.parameters.excludeIstio
                 msg = kubernetes.format(sprintf("%s in the %s %s does not have a memory limit set", [container.name, kubernetes.kind, kubernetes.name]))
         }
+        # ISTIO: https://kubesec.io/basics/containers-resources-limits-memory
+        violation[msg] {
+                kubernetes.containers[container]
+                not container.resources.limits.memory
+                input.parameters.excludeIstio
+                not istio(container.image)
+                msg = kubernetes.format(sprintf("%s in the %s %s does not have a memory limit set", [container.name, kubernetes.kind, kubernetes.name]))
+        }
+
         # https://kubesec.io/basics/containers-resources-limits-cpu/
         violation[msg] {
                 kubernetes.containers[container]
                 not container.resources.limits.cpu
+                not input.parameters.excludeIstio
                 msg = kubernetes.format(sprintf("%s in the %s %s does not have a CPU limit set", [container.name, kubernetes.kind, kubernetes.name]))
         }
-         violation[msg] {
-                 kubernetes.containers[container]
-                 kubernetes.priviledge_escalation_allowed(container)
-                 msg = kubernetes.format(sprintf("%s in the %s %s allows priviledge escalation", [container.name, kubernetes.kind, kubernetes.name]))
-         }
+        # ISTIO: https://kubesec.io/basics/containers-resources-limits-cpu/
+        violation[msg] {
+                kubernetes.containers[container]
+                not container.resources.limits.cpu
+                input.parameters.excludeIstio
+                not istio(container.image)
+                msg = kubernetes.format(sprintf("%s in the %s %s does not have a CPU limit set", [container.name, kubernetes.kind, kubernetes.name]))
+        }
+
+        # Priviledge Escalation
+        violation[msg] {
+                kubernetes.containers[container]
+                kubernetes.priviledge_escalation_allowed(container)
+                not input.parameters.excludeIstio
+                msg = kubernetes.format(sprintf("%s in the %s %s allows priviledge escalation", [container.name, kubernetes.kind, kubernetes.name]))
+        }
+        # ISTIO: # Priviledge Escalation
+        violation[msg] {
+                kubernetes.containers[container]
+                kubernetes.priviledge_escalation_allowed(container)
+                input.parameters.excludeIstio
+                not istio(container.image)
+                msg = kubernetes.format(sprintf("%s in the %s %s allows priviledge escalation", [container.name, kubernetes.kind, kubernetes.name]))
+        }
+
         # https://kubesec.io/basics/containers-securitycontext-runasnonroot-true/
         violation[msg] {
                 kubernetes.containers[container]
                 not container.securityContext.runAsNonRoot = true
+                not input.parameters.excludeIstio
                 msg = kubernetes.format(sprintf("%s in the %s %s is running as root", [container.name, kubernetes.kind, kubernetes.name]))
         }
+        # ISTIO: https://kubesec.io/basics/containers-securitycontext-runasnonroot-true/
+        violation[msg] {
+                kubernetes.containers[container]
+                not container.securityContext.runAsNonRoot = true
+                input.parameters.excludeIstio
+                not istio(container.image)
+                msg = kubernetes.format(sprintf("%s in the %s %s is running as root", [container.name, kubernetes.kind, kubernetes.name]))
+        }
+
         # # https://kubesec.io/basics/containers-securitycontext-capabilities-add-index-sys-admin/
         # violation[msg] {
         #         kubernetes.containers[container]


### PR DESCRIPTION
Ciao team!

While deploying Istio along with the default constraints available in this module, someone can face issues deploying apps into the mesh as they receive a container as a sidecar (aka istio proxy). These sidecars can not be modified so we added a flag in all the constraints to exclude the rule in the sidecar container.

The default behaviour is not affected. If you plan to deploy Istio, make sure to mark the new feature flag as `true`.

Example `K8sLivenessProbe`:
```
---
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: K8sLivenessProbe
metadata:
  name: liveness-probe
spec:
  enforcementAction: deny
  parameters:
    excludeIstio: true # Set this flag to true
```