### PR TITLE
Add GPM manifests to katalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following packages are included in the Fury Kubernetes OPA module:
     - deny of pods that run as root
     - deny of pods that don't declare `livenessProbe` and `readinessProbe`
     - deny of duplicated ingresses
+  - [Gatekeeper Policy Manager](katalog/gatekeeper/gpm): Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. Version: **v0.4.0**
 
 You can click on each package to see its documentation.
 

--- a/katalog/gatekeeper/gpm/README.md
+++ b/katalog/gatekeeper/gpm/README.md
@@ -1,0 +1,56 @@
+# Gatekeeper Policy Manager (GPM)
+
+Gatekeeper Policy Manager is a simple **read-only** web UI for viewing OPA Gatekeeper policies' status in a Kubernetes Cluster.
+
+It can display all the defined **Constraint Templates** with their rego code, and all the **Contraints** with its current status, violations, enforcement action, matches definitions, etc.
+
+## Requirements
+
+You'll need OPA Gatekeeper running in your cluster and at least some constraint templates and constraints defined to take advantage of this tool.
+
+## Deploying GPM
+
+To deploy Gatekeeper Policy Manager to your cluster, apply the provided `kustomization` file running the following command:
+
+```shell
+kubectl apply -k .
+```
+
+By default, this will create a deployment and a service both with the name `gatekeper-policy-manager` in the `gatekeeper-system` namespace. We invite you to take a look into the `kustomization.yaml` file to do further configuration.
+
+We recommend you to create an ingress for the application, you can find a sample [here](https://github.com/sighupio/gatekeeper-policy-manager/blob/v0.4.0/manifests/ingress.yaml)
+
+## Configuration
+
+GPM is a stateless application, but it can be configured using environment variables. The possible configurations are:
+
+| Env Var Name                      | Description                                                                                                       | Default                |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `GPM_AUTH_ENABLED`                | Enable Authentication current options: "Anonymous", "OIDC"                                                        | Anonymous              |
+| `GPM_SECRET_KEY`                  | The secret key used to generate tokens. **Change this value in production**.                                      | `g8k1p3rp0l1c7m4n4g3r` |
+| `GPM_PREFERRED_URL_SCHEME`        | URL scheme to be used while generating links.                                                                     | `http`                 |
+| `GPM_OIDC_REDIRECT_DOMAIN`        | The server name under the app is being exposed. This is where the client will be redirected after authenticating  |
+| `GPM_OIDC_ISSUER`                 | OIDC Issuer hostname                                                                                              |
+| `GPM_OIDC_AUTHORIZATION_ENDPOINT` | OIDC Authorizatoin Endpoint                                                                                       |
+| `GPM_OIDC_JWKS_URI`               | OIDC JWKS URI                                                                                                     |
+| `GPM_OIDC_TOKEN_ENDPOINT`         | OIDC TOKEN Endpoint                                                                                               |
+| `GPM_OIDC_INTROSPECTION_ENDPOINT` | OIDC Introspection Enpoint                                                                                        |
+| `GPM_OIDC_USERINFO_ENDPOINT`      | OIDC Userinfo Endpoint                                                                                            |
+| `GPM_OIDC_END_SESSION_ENDPOINT`   | OIDC End Session Endpoint                                                                                         |
+| `GPM_OIDC_CLIENT_ID`              | The Client ID used to authenticate against the OIDC Provider                                                      |
+| `GPM_OIDC_CLIENT_SECRET`          | The Client Secret used to authenticate against the OIDC Provider                                                  |
+| `GPM_LOG_LEVEL`                   | Log level (see [python logging docs](https://docs.python.org/2/library/logging.html#levels) for available levels) | `INFO`                 |
+
+> ⚠️ Please notice that OIDC Authentication is in beta state. It has been tested to work with Keycloak as a provider.
+
+You can find a sample patch for these environment variables in the upstream [`enable-oidc.yaml`](https://github.com/sighupio/gatekeeper-policy-manager/blob/v0.4.0/manifests/enable-oidc.yaml) file.
+
+Apply it as a patch, like this:
+
+```yaml
+patchesStrategicMerge:
+  - enable-oidc.yaml
+```
+
+More information on the official repository: <https://github.com/sighupio/gatekeeper-policy-manager>
+

--- a/katalog/gatekeeper/gpm/kustomization.yaml
+++ b/katalog/gatekeeper/gpm/kustomization.yaml
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+namespace: gatekeeper-system
+
 bases:
-  - core
-  - rules
-  - monitoring
-  - gpm
+  - https://github.com/sighupio/gatekeeper-policy-manager/?ref=v0.4.0
+


### PR DESCRIPTION
This PR adds Gatekeeper Policy Manager's manifests to the fury-kubernetes-opa module so you can install GPM together in one shot. 