### PR TITLE
Reduce gatekeeper webhook timeout for 5s to 3s

### DIFF
--- a/katalog/gatekeeper/core/vwh.yml
+++ b/katalog/gatekeeper/core/vwh.yml
@@ -33,7 +33,7 @@ webhooks:
         resources:
           - "*"
     sideEffects: None
-    timeoutSeconds: 5
+    timeoutSeconds: 3
   - clientConfig:
       caBundle: Cg==
       service:
@@ -53,4 +53,4 @@ webhooks:
         resources:
           - namespaces
     sideEffects: None
-    timeoutSeconds: 5
+    timeoutSeconds: 3


### PR DESCRIPTION
See https://github.com/open-policy-agent/gatekeeper/issues/870

This commit aligns the vwh to the Gatekeeper upstream, and also fixes the below bug.

### How the bug affected us:
We were creating a new K8s 1.18 cluster with Fury 1.5.1 on OCI, using only a single master node.
When we applied all manifests at the same time, gatekeeper got deployed with 5 sec webhook timeout.
We observed that the cluster reached a broken, nonfunctional state -
e.g. no new pods could start, CNI seemed broken, and some core components were crashlooping.
Apiserver was full of errors about API requests timing out.

After a couple days of debugging, we found out that Gatekeeper was the issue.
The linked github issue perfectly fits our case.
Indeed, reducing the vwh timeout from 5 sec to 3 sec "repairs" the cluster quite quickly.