### PR TITLE
Upgrade module 1.4.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ name: license
 
 steps:
   - name: check
-    image: docker.io/library/golang:1.14.3
+    image: docker.io/library/golang:1.16
     pull: always
     commands:
       - go get -u github.com/google/addlicense
@@ -31,7 +31,7 @@ steps:
       - clone
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.8_3.8.7_2.4.1
     pull: always
     depends_on:
       - clone
@@ -39,106 +39,12 @@ steps:
       - kustomize build katalog/gatekeeper > gatekeeper.yml
 
   - name: deprek8ion
-    image: eu.gcr.io/swade1987/deprek8ion:1.1.32
+    image: eu.gcr.io/swade1987/deprek8ion:1.1.34
     pull: always
     depends_on:
       - render
     commands:
       - /conftest test -p /policies gatekeeper.yml
-
----
-kind: pipeline
-name: e2e-kubernetes-1.17
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-117
-      pipeline_id: cluster-117
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.17.5'
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.11_3.3.0_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - bats -t katalog/tests/gatekeeper.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
-    pull: always
-    depends_on: [ e2e ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-117
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
 
 ---
 kind: pipeline
@@ -157,7 +63,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
     pull: always
     volumes:
     - name: shared
@@ -167,7 +73,7 @@ steps:
       action: custom-cluster-118
       pipeline_id: cluster-118
       local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.18.8'
+      cluster_version: '1.18.15'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -189,7 +95,7 @@ steps:
         from_secret: dockerhub_password
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.8_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -200,7 +106,7 @@ steps:
       - bats -t katalog/tests/gatekeeper.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -250,7 +156,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
     pull: always
     volumes:
     - name: shared
@@ -260,7 +166,7 @@ steps:
       action: custom-cluster-119
       pipeline_id: cluster-119
       local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.19.4'
+      cluster_version: '1.19.7'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -282,7 +188,7 @@ steps:
         from_secret: dockerhub_password
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.19.4_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.19.4_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -293,7 +199,7 @@ steps:
       - bats -t katalog/tests/gatekeeper.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -344,7 +250,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
     pull: always
     volumes:
     - name: shared
@@ -354,7 +260,7 @@ steps:
       action: custom-cluster-120
       pipeline_id: cluster-120
       local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.20.0'
+      cluster_version: '1.20.2'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -376,7 +282,7 @@ steps:
         from_secret: dockerhub_password
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.20.0_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -387,7 +293,7 @@ steps:
       - bats -t katalog/tests/gatekeeper.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -425,9 +331,9 @@ kind: pipeline
 name: release
 
 depends_on:
-  - e2e-kubernetes-1.17
   - e2e-kubernetes-1.18
   - e2e-kubernetes-1.19
+  - e2e-kubernetes-1.20
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ steps:
       - clone
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.8_3.8.7_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
     pull: always
     depends_on:
       - clone
@@ -63,7 +63,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     pull: always
     volumes:
     - name: shared
@@ -73,7 +73,7 @@ steps:
       action: custom-cluster-118
       pipeline_id: cluster-118
       local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.18.15'
+      cluster_version: '1.18.19'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -95,7 +95,7 @@ steps:
         from_secret: dockerhub_password
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.8_3.8.7_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -106,7 +106,7 @@ steps:
       - bats -t katalog/tests/gatekeeper.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -156,7 +156,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     pull: always
     volumes:
     - name: shared
@@ -166,7 +166,7 @@ steps:
       action: custom-cluster-119
       pipeline_id: cluster-119
       local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.19.7'
+      cluster_version: '1.19.11'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -188,7 +188,7 @@ steps:
         from_secret: dockerhub_password
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.19.4_3.8.7_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.19.11_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -199,7 +199,7 @@ steps:
       - bats -t katalog/tests/gatekeeper.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -250,7 +250,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     pull: always
     volumes:
     - name: shared
@@ -260,7 +260,7 @@ steps:
       action: custom-cluster-120
       pipeline_id: cluster-120
       local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.20.2'
+      cluster_version: '1.20.7'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -282,7 +282,7 @@ steps:
         from_secret: dockerhub_password
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.20.0_3.8.7_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.20.7_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -293,12 +293,106 @@ steps:
       - bats -t katalog/tests/gatekeeper.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.10.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     pull: always
     depends_on: [ e2e ]
     settings:
       action: destroy
       pipeline_id: cluster-120
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+
+---
+kind: pipeline
+name: e2e-kubernetes-1.21
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-121
+      pipeline_id: cluster-121
+      local_kind_config_path: katalog/tests/kind/config.yml
+      cluster_version: '1.21.1'
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+
+  - name: e2e
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.21.1_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-121
+      - bats -t katalog/tests/gatekeeper.sh
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    pull: always
+    depends_on: [ e2e ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-121
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:

--- a/README.md
+++ b/README.md
@@ -40,21 +40,23 @@ file if you don't want to install the monitoring module.
 
 ## Compatibility
 
-| Module Version / Kubernetes Version |       1.14.X       |       1.15.X       |       1.16.X       |       1.17.X       |       1.18.X       |       1.19.X       |       1.20.X       |
-| ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| v1.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
-| v1.0.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
-| v1.0.2                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
-| v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
-| v1.2.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |                    |
-| v1.2.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |                    |
-| v1.3.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
-| v1.3.1                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
-| v1.4.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version |       1.14.X       |       1.15.X       |       1.16.X       |       1.17.X       |       1.18.X       |       1.19.X       |       1.20.X       |  1.21.X   |
+| ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :-------: |
+| v1.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |           |
+| v1.0.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |           |
+| v1.0.2                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |           |
+| v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |           |
+| v1.2.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |                    |           |
+| v1.2.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |                    |           |
+| v1.3.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |           |
+| v1.3.1                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |           |
+| v1.4.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
 
 ### Warning
 
 - :warning: : module version: `v1.3.0` along with Kubernetes Version: `1.20.x`. It works as expected.
+Marked as a warning because it is not officially supported by [SIGHUP](https://sighup.io).
+- :warning: : module version: `v1.4.0` along with Kubernetes Version: `1.21.x`. It works as expected.
 Marked as a warning because it is not officially supported by [SIGHUP](https://sighup.io).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Kubernetes Cluster.
 
 The following packages are included in the Fury Kubernetes OPA module:
 
-- [Gatekeeper](katalog/gatekeeper): Ready to use gatekeeper deployment plus a set of rules. Version: **v3.2.2**
-  - [Gatekeeper Core](katalog/gatekeeper/core): Gatekeeper deployment, ready to apply rules. Version: **v3.2.2**
+- [Gatekeeper](katalog/gatekeeper): Ready to use gatekeeper deployment plus a set of rules. Version: **v3.4.0**
+  - [Gatekeeper Core](katalog/gatekeeper/core): Gatekeeper deployment, ready to apply rules. Version: **v3.4.0**
   - [Gatekeeper Rules](katalog/gatekeeper/rules): Gatekeeper rules:
     - deny of docker images with the latest tag
     - deny of pods that have no limit declared (both CPU and memory)
@@ -16,7 +16,9 @@ The following packages are included in the Fury Kubernetes OPA module:
     - deny of pods that run as root
     - deny of pods that don't declare `livenessProbe` and `readinessProbe`
     - deny of duplicated ingresses
-  - [Gatekeeper Policy Manager](katalog/gatekeeper/gpm): Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. Version: **v0.4.2**
+    - Unique service selector
+  - [Gatekeeper Policy Manager](katalog/gatekeeper/gpm): Gatekeeper Policy Manager, a simple to use web-ui for
+  Gatekeeper. Version: **v0.4.2**
 
 You can click on each package to see its documentation.
 
@@ -25,7 +27,7 @@ You can click on each package to see its documentation.
 All packages in this repository have the following dependencies, for package
 specific dependencies please visit the single package's documentation:
 
-- [Kubernetes](https://kubernetes.io) >= `v1.17.0`
+- [Kubernetes](https://kubernetes.io) >= `v1.18.0`
 - [Furyctl](https://github.com/sighupio/furyctl) package manager to download
     Fury packages >= [`v0.2.2`](https://github.com/sighupio/furyctl/releases/tag/v0.2.2)
 - [Kustomize](https://github.com/kubernetes-sigs/kustomize) = `v3.3.0`
@@ -47,6 +49,8 @@ file if you don't want to install the monitoring module.
 | v1.2.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |                    |
 | v1.2.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |                    |
 | v1.3.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
+| v1.3.1                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
+| v1.4.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 ### Warning
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,5 +1,0 @@
-# unreleased version
-
-## Changes from v1.3.1
-
-- Updated GPM to v0.4.2

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -12,6 +12,7 @@ Continue reading the [Changelog](#changelog) to discover them:
 - Kubernetes support:
   - Deprecate Kubernetes 1.17 support.
   - Kubernetes 1.20 is considered stable.
+  - Kubernetes 1.21 is considered tech preview.
 - Add a missing template *(`unique_service_selector_template`)* to the template package.
 - Updated GPM to v0.4.2
 

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -1,0 +1,25 @@
+# OPA Core Module version v1.4.0
+
+SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
+Minor works have been done in the constraint templates while updating the OPA Gatekeeper package.
+
+Continue reading the [Changelog](#changelog) to discover them:
+
+## Changelog
+
+- Update OPA Gatekeeper version from: 3.2.2 to [3.4.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.4.0)
+  - Add Pod Disruption Budget
+- Kubernetes support:
+  - Deprecate Kubernetes 1.17 support.
+  - Kubernetes 1.20 is considered stable.
+- Add a missing template *(`unique_service_selector_template`)* to the template package.
+- Updated GPM to v0.4.2
+
+## Upgrade path
+
+To upgrade this core module from `v1.3.1`, you need to download this new version, then apply the
+`kustomize` project. No further action is required.
+
+```bash
+kustomize build katalog/gatekeeper | kubectl apply -f - --force
+```

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -1,7 +1,8 @@
 # OPA Core Module version v1.4.0
 
 SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
-Minor works have been done in the constraint templates while updating the OPA Gatekeeper package.
+With the Kubernetes 1.21 release, it became the perfect time to start testing this module against this Kubernetes
+release.
 
 Continue reading the [Changelog](#changelog) to discover them:
 
@@ -14,7 +15,7 @@ Continue reading the [Changelog](#changelog) to discover them:
   - Kubernetes 1.20 is considered stable.
   - Kubernetes 1.21 is considered tech preview.
 - Add a missing template *(`unique_service_selector_template`)* to the template package.
-- Updated GPM to v0.4.2
+- Updated GPM to v0.4.2. Thanks to @ralgozino
 
 ## Upgrade path
 

--- a/katalog/gatekeeper/README.md
+++ b/katalog/gatekeeper/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Minimum Kubernetes version >= 1.17
+Minimum Kubernetes version >= 1.18
 
 > Requires the `ValidatingAdmissionWebhook` admission plugin
 

--- a/katalog/gatekeeper/core/crd.yml
+++ b/katalog/gatekeeper/core/crd.yml
@@ -24,16 +24,10 @@ spec:
       description: Config is the Schema for the configs API
       properties:
         apiVersion:
-          description:
-            "APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description:
-            "Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -64,9 +58,7 @@ spec:
               description: Configuration for syncing k8s objects
               properties:
                 syncOnly:
-                  description:
-                    If non-empty, only entries on this list will be replicated
-                    into OPA
+                  description: If non-empty, only entries on this list will be replicated into OPA
                   items:
                     properties:
                       group:
@@ -82,15 +74,11 @@ spec:
               description: Configuration for validation
               properties:
                 traces:
-                  description:
-                    List of requests to trace. Both "user" and "kinds"
-                    must be specified
+                  description: List of requests to trace. Both "user" and "kinds" must be specified
                   items:
                     properties:
                       dump:
-                        description:
-                          Also dump the state of OPA with the trace. Set
-                          to `All` to dump everything.
+                        description: Also dump the state of OPA with the trace. Set to `All` to dump everything.
                         type: string
                       kind:
                         description: Only trace requests of the following GroupVersionKind
@@ -115,9 +103,9 @@ spec:
       type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""
@@ -291,16 +279,10 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
-          description:
-            "APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description:
-            "Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -352,8 +334,8 @@ spec:
                         message:
                           type: string
                       required:
-                        - code
-                        - message
+                      - code
+                      - message
                       type: object
                     type: array
                   id:
@@ -369,12 +351,12 @@ spec:
           type: object
   version: v1beta1
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
-    - name: v1alpha1
-      served: true
-      storage: false
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/katalog/gatekeeper/core/deploy.yml
+++ b/katalog/gatekeeper/core/deploy.yml
@@ -7,7 +7,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: audit-controller
     gatekeeper.sh/operation: audit
     gatekeeper.sh/system: "yes"
   name: gatekeeper-audit
@@ -27,6 +27,7 @@ spec:
         gatekeeper.sh/operation: audit
         gatekeeper.sh/system: "yes"
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --operation=audit
@@ -74,6 +75,7 @@ spec:
           capabilities:
             drop:
             - all
+          readOnlyRootFilesystem: true
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000
@@ -170,6 +172,7 @@ spec:
             capabilities:
               drop:
                 - all
+            readOnlyRootFilesystem: true
             runAsGroup: 999
             runAsNonRoot: true
             runAsUser: 1000

--- a/katalog/gatekeeper/core/kustomization.yaml
+++ b/katalog/gatekeeper/core/kustomization.yaml
@@ -17,8 +17,9 @@ resources:
   - deploy.yml
   - svc.yml
   - vwh.yml
+  - pdb.yml
 
 images:
   - name: openpolicyagent/gatekeeper
     newName: registry.sighup.io/fury/openpolicyagent/gatekeeper
-    newTag: v3.2.2
+    newTag: v3.4.0

--- a/katalog/gatekeeper/core/pdb.yml
+++ b/katalog/gatekeeper/core/pdb.yml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-controller-manager
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      gatekeeper.sh/operation: webhook
+      gatekeeper.sh/system: "yes"

--- a/katalog/gatekeeper/rules/README.md
+++ b/katalog/gatekeeper/rules/README.md
@@ -6,6 +6,7 @@
 - deny of pods that run as root
 - deny of pods that don't declare `livenessProbe` and `readinessProbe`
 - deny duplicated ingresses
+- unique service selector
 
 [security_controls_template.yml](templates/security_controls_template.yml): it's an all in one pod security policies
 measures, that contains a lot more rules, that are currently commented on. This file can be splitter into several

--- a/katalog/gatekeeper/rules/templates/kustomization.yaml
+++ b/katalog/gatekeeper/rules/templates/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - unique_ingress_template.yml
   - livenessprobe_template.yml
   - readinessproble_template.yml
+  - unique_service_selector_template.yml

--- a/katalog/tests/gatekeeper.sh
+++ b/katalog/tests/gatekeeper.sh
@@ -136,7 +136,7 @@ set -o pipefail
   }
   run deploy
   [[ "$status" -ne 0 ]]
-  [[ "$output" == *"denied by enforce-deployment-and-pod-security-controls"* ]]
+  [[ "$output" == *"using the latest tag"* ]]
 }
 
 @test "[DENY] Deployment without resources" {
@@ -146,7 +146,7 @@ set -o pipefail
   }
   run deploy
   [[ "$status" -ne 0 ]]
-  [[ "$output" == *"denied by enforce-deployment-and-pod-security-controls"* ]]
+  [[ "$output" == *"enforce-deployment-and-pod-security-controls"* ]]
 }
 
 @test "[DENY] Pod without liveness/readiness probes" {
@@ -156,7 +156,7 @@ set -o pipefail
   }
   run deploy
   [[ "$status" -ne 0 ]]
-  [[ "$output" == *"denied by liveness-probe"* ]]
+  [[ "$output" == *"liveness-probe"* ]]
 }
 
 @test "[DENY] Duplicated ingress" {
@@ -166,7 +166,7 @@ set -o pipefail
   }
   run deploy
   [[ "$status" -ne 0 ]]
-  [[ "$output" == *"denied by unique-ingress-host"* ]]
+  [[ "$output" == *"unique-ingress-host"* ]]
 }
 
 @test "Teardown - Delete resources" {


### PR DESCRIPTION
# OPA Core Module version v1.4.0

SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
Minor works have been done in the constraint templates while updating the OPA Gatekeeper package.

Continue reading the [Changelog](#changelog) to discover them:

## Changelog

- Update OPA Gatekeeper version from: 3.2.2 to [3.4.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.4.0)
  - Add Pod Disruption Budget
- Kubernetes support:
  - Deprecate Kubernetes 1.17 support.
  - Kubernetes 1.20 is considered stable.
- Add a missing template *(`unique_service_selector_template`)* to the template package.
- Updated GPM to v0.4.2

## Upgrade path

To upgrade this core module from `v1.3.1`, you need to download this new version, then apply the
`kustomize` project. No further action is required.

```bash
kustomize build katalog/gatekeeper | kubectl apply -f - --force
```
