### PR TITLE
add missing temp volume to gatekeeper-audit

### DIFF
--- a/katalog/gatekeeper/core/deploy.yml
+++ b/katalog/gatekeeper/core/deploy.yml
@@ -81,10 +81,16 @@ spec:
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000
+        volumeMounts:
+        - mountPath: /tmp/audit
+          name: tmp-volume
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: gatekeeper-admin
       terminationGracePeriodSeconds: 60
+      volumes:
+      - emptyDir: {}
+        name: tmp-volume
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR adds a missing temp volume to Gatekeeper's Audit pod. Without this volume the audit is not working, you get this error:

```
{"level":"error","ts":1644408172.8148265,"logger":"controller","msg":"audit manager audit() failed","process":"audit","error":"open /tmp/audit: no such file or directory","stacktrace":"github.com/open-policy-agent/gatekeeper/pkg/audit.(*Manager).auditManagerLoop\n\t/go/src/github.com/open-policy-agent/gatekeeper/pkg/audit/manager.go:561"}
```

policy enforcement when you apply a new object is unaffected by this issue though