### PR TITLE
[DOCS] - Update readme with the upcoming furyctl v1.0.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ bases:
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
 
-2. Execute `furyctl vendor -H` to download the packages
+2. Execute `furyctl distribution download -H` to download the packages
 
 3. Inspect the download packages under `./vendor/katalog/opa/gatekeeper`.
 


### PR DESCRIPTION
As per title, updating furyctl reference to use the new command structure of the upcoming v1.0.0 version