### PR TITLE
GPM: use local files instead of remote manifests.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,6 +44,8 @@ steps:
       VALIDATE_JSCPD: "false"
       # hadolint already validated dockerfiles
       VALIDATE_DOCKERFILE: "false"
+      # Disable natural language checks
+      VALIDATE_NATURAL_LANGUAGE: "false"
     depends_on:
       - clone
 

--- a/katalog/gatekeeper/gpm/MAINTENANCE.md
+++ b/katalog/gatekeeper/gpm/MAINTENANCE.md
@@ -1,6 +1,6 @@
 # Gatekeeper Policy Manager Package Maintenance
 
-To maintain the GPM package, you'll need to keep updated with upstream the following files:
+To maintain the GPM package, you'll need to keep updated with upstream the following files (check the main `README.md` for the upstream prioject link):
 
 - `README.md`
 - `*.yaml`

--- a/katalog/gatekeeper/gpm/MAINTENANCE.md
+++ b/katalog/gatekeeper/gpm/MAINTENANCE.md
@@ -1,0 +1,10 @@
+# Gatekeeper Policy Manager Package Maintenance
+
+To maintain the GPM package, you'll need to keep updated with upstream the following files:
+
+- `README.md`
+- `*.yaml`
+
+For the readme, the important section to keep updated is the configuration parameters table.
+
+For the manifests files (`*.yaml`), you'll need to download the files from upstream and diff them to the local ones. You can find the url of each one as a comment in the first lines.

--- a/katalog/gatekeeper/gpm/MAINTENANCE.md
+++ b/katalog/gatekeeper/gpm/MAINTENANCE.md
@@ -7,4 +7,4 @@ To maintain the GPM package, you'll need to keep updated with upstream the follo
 
 For the readme, the important section to keep updated is the configuration parameters table.
 
-For the manifests files (`*.yaml`), you'll need to download the files from upstream and diff them to the local ones. You can find the url of each one as a comment in the first lines.
+For the manifests files (`*.yaml`), you'll need to download the files from upstream and diff them to the local ones. You can find the URL of each one as a comment in the first lines.

--- a/katalog/gatekeeper/gpm/deployment.yaml
+++ b/katalog/gatekeeper/gpm/deployment.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Taken from: https://github.com/sighupio/gatekeeper-policy-manager/blob/main/manifests/deployment.yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gatekeeper-policy-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gatekeeper-policy-manager
+  template:
+    metadata:
+      labels:
+        app: gatekeeper-policy-manager
+    spec:
+      serviceAccountName: gatekeeper-policy-manager
+      containers:
+      - name: gatekeeper-policy-manager
+        image: quay.io/sighup/gatekeeper-policy-manager
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+        livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+        readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+        ports:
+        - containerPort: 8080
+          name: http
+        securityContext:
+          privileged: false
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false

--- a/katalog/gatekeeper/gpm/kustomization.yaml
+++ b/katalog/gatekeeper/gpm/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -9,7 +9,9 @@ kind: Kustomization
 namespace: gatekeeper-system
 
 resources:
-  - https://github.com/sighupio/gatekeeper-policy-manager/?ref=v0.5.1
+  - rbac.yaml
+  - deployment.yaml
+  - service.yaml
 
 images:
   - name: quay.io/sighup/gatekeeper-policy-manager

--- a/katalog/gatekeeper/gpm/rbac.yaml
+++ b/katalog/gatekeeper/gpm/rbac.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Taken from: https://github.com/sighupio/gatekeeper-policy-manager/blob/main/manifests/rbac.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gatekeeper-policy-manager
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gatekeeper-policy-manager-crd-view
+rules:
+- apiGroups: ["constraints.gatekeeper.sh"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["templates.gatekeeper.sh"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["config.gatekeeper.sh"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gatekeeper-policy-manager-crd-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gatekeeper-policy-manager-crd-view
+subjects:
+- kind: ServiceAccount
+  name: gatekeeper-policy-manager
+  namespace: gatekeeper-system

--- a/katalog/gatekeeper/gpm/service.yaml
+++ b/katalog/gatekeeper/gpm/service.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Taken from: https://github.com/sighupio/gatekeeper-policy-manager/blob/main/manifests/service.yaml
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: gatekeeper-policy-manager
+spec:
+  selector:
+    app: gatekeeper-policy-manager
+  ports:
+  - port: 80
+    targetPort: http


### PR DESCRIPTION
This PR takes the manifests for the GPM package from upstream and renders them local to fix #21.

Adds also a `MAINTENANCE.md` file with instructions.