### PR TITLE
Bugfix: set audit chunksize by default

### DIFF
--- a/katalog/gatekeeper/core/MAINTENANCE.md
+++ b/katalog/gatekeeper/core/MAINTENANCE.md
@@ -1,0 +1,14 @@
+# Gatekepeer Package Maintenance
+
+```bash
+curl https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.7/deploy/gatekeeper.yaml -o upstream.yaml
+cat ns.yml crd.yml sa.yml rbac.yml vwh.yml secret.yml svc.yml deploy.yml pdb.yml > local.yml
+```
+
+diff `local.yaml` with `upstream.yaml` and port the needed differences.
+
+## Customizations
+
+The deployment for audit-controller has been customized setting a default value for `--audit-chunk-size` to avoid the audit-controller going into OOM. We've observed this behaviour in serveral clusters, and this seems to fix it.
+
+See [issue #49](https://github.com/sighupio/fury-kubernetes-opa/issues/49)

--- a/katalog/gatekeeper/core/deploy.yml
+++ b/katalog/gatekeeper/core/deploy.yml
@@ -35,6 +35,10 @@ spec:
         - --logtostderr
         - --health-addr=:9090
         - --prometheus-port=8888
+        # setting audit-chunk-size to avoid audit going in OOM.
+        # This is not a default from upstream.
+        # see: https://github.com/sighupio/fury-kubernetes-opa/issues/49
+        - --audit-chunk-size=500
         command:
         - /manager
         env:


### PR DESCRIPTION
Being that setting this parameter doesn't seem to have downsides nor caused any issues until now, we proceed to set it by default.

This PR also adds a `MAINTENACE.md` for Gatekeeper