### PR TITLE
bugfix: Audit skipped on provided Constraints

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -3,7 +3,7 @@
 
 Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 
-This is a major release updating the Gatekeeper package to the latest version upstream.
+This is a major release updating the Gatekeeper package to the latest version upstream and fixing a bug in the provided ConstraintTemplates that made the audit not to trigger.
 
 ## Component Images 🚢
 

--- a/katalog/gatekeeper/rules/templates/livenessprobe_template.yml
+++ b/katalog/gatekeeper/rules/templates/livenessprobe_template.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -21,15 +21,22 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8slivenessprobe
+        is_create_update_or_audit {
+            operation := input.review.operation
+            any([ operation == "CREATE", operation == "UPDATE" ])
+            operation != "DELETE"
+        }
+        is_create_update_or_audit {
+            # When the constraint is run by the audit process input.review is not set
+            input.review.operation == ""
+        }
         violation[{"msg": msg}] {
             containers := input.review.object.spec.template.spec.containers[_]
             name := input.review.object.metadata.name
             kind := input.review.kind.kind
+            is_create_update_or_audit
             not containers.livenessProbe
             not input.parameters.excludeIstio
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -38,9 +45,7 @@ spec:
             kind := input.review.kind.kind
             not containers.livenessProbe
             not input.parameters.excludeIstio
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -49,9 +54,7 @@ spec:
             kind := input.review.kind.kind
             not containers.livenessProbe
             not input.parameters.excludeIstio
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
         }
 
@@ -62,9 +65,7 @@ spec:
             not containers.livenessProbe
             input.parameters.excludeIstio
             not istio(containers.image)
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
         }
 
@@ -75,9 +76,7 @@ spec:
             not containers.livenessProbe
             input.parameters.excludeIstio
             not istio(containers.image)
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
         }
 
@@ -88,9 +87,7 @@ spec:
             not containers.livenessProbe
             input.parameters.excludeIstio
             not istio(containers.image)
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a livenessProbe", [kind, name])
         }
 

--- a/katalog/gatekeeper/rules/templates/protected_namespace.yml
+++ b/katalog/gatekeeper/rules/templates/protected_namespace.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -16,13 +16,21 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8sprotectednamespace
+        is_delete_or_audit {
+            operation := input.review.operation
+            operation == "DELETE"
+        }
+        is_delete_or_audit {
+            # When the constraint is run by the audit process input.review is not set
+            input.review.operation == ""
+        }
 
         violation[{"msg": msg}] {
           name := input.review.object.metadata.name
           kind := input.review.object.kind
           operation :=  input.review.operation
           kind == "Namespace"
-          operation == "DELETE"
+          is_delete_or_audit
           not input.review.object.metadata.annotations["opa.sighup.io/indelible-ns"] == "no"
           msg := sprintf("the namespace '%s' is protected, so it cannot be deleted. Add an annotation 'opa.sighup.io/indelible-ns=no' to it to unprotect it.", [name])
         }

--- a/katalog/gatekeeper/rules/templates/readinessproble_template.yml
+++ b/katalog/gatekeeper/rules/templates/readinessproble_template.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 

--- a/katalog/gatekeeper/rules/templates/readinessproble_template.yml
+++ b/katalog/gatekeeper/rules/templates/readinessproble_template.yml
@@ -21,15 +21,22 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8sreadinessprobe
+        is_create_update_or_audit {
+            operation := input.review.operation
+            any([ operation == "CREATE", operation == "UPDATE" ])
+            operation != "DELETE"
+        }
+        is_create_update_or_audit {
+            # When the constraint is run by the audit process input.review is not set
+            input.review.operation == ""
+        }
         violation[{"msg": msg}] {
             containers := input.review.object.spec.template.spec.containers[_]
             name := input.review.object.metadata.name
             kind := input.review.kind.kind
             not containers.readinessProbe
             not input.parameters.excludeIstio
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -38,9 +45,7 @@ spec:
             kind := input.review.kind.kind
             not containers.readinessProbe
             not input.parameters.excludeIstio
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -49,9 +54,7 @@ spec:
             kind := input.review.kind.kind
             not containers.readinessProbe
             not input.parameters.excludeIstio
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
         }
 
@@ -62,9 +65,7 @@ spec:
             not containers.readinessProbe
             input.parameters.excludeIstio
             not istio(containers.image)
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -74,9 +75,7 @@ spec:
             not containers.readinessProbe
             input.parameters.excludeIstio
             not istio(containers.image)
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
         }
         violation[{"msg": msg}] {
@@ -86,9 +85,7 @@ spec:
             not containers.readinessProbe
             input.parameters.excludeIstio
             not istio(containers.image)
-            operation := input.review.operation
-            any([ operation == "CREATE", operation == "UPDATE" ])
-            operation != "DELETE"
+            is_create_update_or_audit
             msg = sprintf("Rejecting \"%v/%v\" for not specifying a readinessProbe", [kind, name])
         }
 

--- a/katalog/gatekeeper/rules/templates/security_controls_template.yml
+++ b/katalog/gatekeeper/rules/templates/security_controls_template.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 

--- a/katalog/gatekeeper/rules/templates/security_controls_template.yml
+++ b/katalog/gatekeeper/rules/templates/security_controls_template.yml
@@ -112,15 +112,21 @@ spec:
         istio(image) {
                 contains(image, "istio/proxyv2")
         }
-
+        is_create_update_or_audit {
+            operation := input.review.operation
+            any([ operation == "CREATE", operation == "UPDATE" ])
+            operation != "DELETE"
+        }
+        is_create_update_or_audit {
+            # When the constraint is run by the audit process input.review is not set
+            input.review.operation == ""
+        }
         # Latests
         violation[msg] {
                 kubernetes.containers[container]
                 [image_name, "latest"] = kubernetes.split_image(container.image)
                 not input.parameters.excludeIstio
-                operation := input.review.operation
-                any([ operation == "CREATE", operation == "UPDATE" ])
-                operation != "DELETE"
+                is_create_update_or_audit
                 msg = kubernetes.format(sprintf("%s in the %s %s has an image, %s, using the latest tag", [container.name, kubernetes.kind, image_name, kubernetes.name]))
         }
         # ISTIO: Latests
@@ -129,9 +135,7 @@ spec:
                 [image_name, "latest"] = kubernetes.split_image(container.image)
                 input.parameters.excludeIstio
                 not istio(container.image)
-                operation := input.review.operation
-                any([ operation == "CREATE", operation == "UPDATE" ])
-                operation != "DELETE"
+                is_create_update_or_audit
                 msg = kubernetes.format(sprintf("%s in the %s %s has an image, %s, using the latest tag", [container.name, kubernetes.kind, image_name, kubernetes.name]))
         }
 
@@ -151,9 +155,7 @@ spec:
                 not container.resources.limits.memory
                 input.parameters.excludeIstio
                 not istio(container.image)
-                operation := input.review.operation
-                any([ operation == "CREATE", operation == "UPDATE" ])
-                operation != "DELETE"
+                is_create_update_or_audit
                 msg = kubernetes.format(sprintf("%s in the %s %s does not have a memory limit set", [container.name, kubernetes.kind, kubernetes.name]))
         }
 
@@ -162,9 +164,7 @@ spec:
                 kubernetes.containers[container]
                 not container.resources.limits.cpu
                 not input.parameters.excludeIstio
-                operation := input.review.operation
-                any([ operation == "CREATE", operation == "UPDATE" ])
-                operation != "DELETE"
+                is_create_update_or_audit
                 msg = kubernetes.format(sprintf("%s in the %s %s does not have a CPU limit set", [container.name, kubernetes.kind, kubernetes.name]))
         }
         # ISTIO: https://kubesec.io/basics/containers-resources-limits-cpu/
@@ -173,9 +173,7 @@ spec:
                 not container.resources.limits.cpu
                 input.parameters.excludeIstio
                 not istio(container.image)
-                operation := input.review.operation
-                any([ operation == "CREATE", operation == "UPDATE" ])
-                operation != "DELETE"
+                is_create_update_or_audit
                 msg = kubernetes.format(sprintf("%s in the %s %s does not have a CPU limit set", [container.name, kubernetes.kind, kubernetes.name]))
         }
 
@@ -184,9 +182,7 @@ spec:
                 kubernetes.containers[container]
                 kubernetes.priviledge_escalation_allowed(container)
                 not input.parameters.excludeIstio
-                operation := input.review.operation
-                any([ operation == "CREATE", operation == "UPDATE" ])
-                operation != "DELETE"
+                is_create_update_or_audit
                 msg = kubernetes.format(sprintf("%s in the %s %s allows priviledge escalation", [container.name, kubernetes.kind, kubernetes.name]))
         }
         # ISTIO: # Priviledge Escalation
@@ -195,9 +191,7 @@ spec:
                 kubernetes.priviledge_escalation_allowed(container)
                 input.parameters.excludeIstio
                 not istio(container.image)
-                operation := input.review.operation
-                any([ operation == "CREATE", operation == "UPDATE" ])
-                operation != "DELETE"
+                is_create_update_or_audit
                 msg = kubernetes.format(sprintf("%s in the %s %s allows priviledge escalation", [container.name, kubernetes.kind, kubernetes.name]))
         }
 
@@ -206,9 +200,7 @@ spec:
                 kubernetes.containers[container]
                 not container.securityContext.runAsNonRoot = true
                 not input.parameters.excludeIstio
-                operation := input.review.operation
-                any([ operation == "CREATE", operation == "UPDATE" ])
-                operation != "DELETE"
+                is_create_update_or_audit
                 msg = kubernetes.format(sprintf("%s in the %s %s is running as root", [container.name, kubernetes.kind, kubernetes.name]))
         }
         # ISTIO: https://kubesec.io/basics/containers-securitycontext-runasnonroot-true/
@@ -217,9 +209,7 @@ spec:
                 not container.securityContext.runAsNonRoot = true
                 input.parameters.excludeIstio
                 not istio(container.image)
-                operation := input.review.operation
-                any([ operation == "CREATE", operation == "UPDATE" ])
-                operation != "DELETE"
+                is_create_update_or_audit
                 msg = kubernetes.format(sprintf("%s in the %s %s is running as root", [container.name, kubernetes.kind, kubernetes.name]))
         }
 

--- a/katalog/gatekeeper/rules/templates/unique_ingress_template.yml
+++ b/katalog/gatekeeper/rules/templates/unique_ingress_template.yml
@@ -16,7 +16,16 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8suniqueingresshost
-
+        is_create_update_or_audit {
+            operation := input.review.operation
+            any([ operation == "CREATE", operation == "UPDATE" ])
+            operation != "DELETE"
+        }
+        is_create_update_or_audit {
+            # When the constraint is run by the audit process input.review is not set
+            input.review.operation == ""
+        }
+        
         violation[{"msg": msg}] {
           input.review.kind.kind == "Ingress"
           re_match("^(extensions|networking.k8s.io)$", input.review.kind.group)
@@ -46,9 +55,7 @@ spec:
           common_paths := input_paths & other_paths
           count(common_paths) != 0
 
-          operation := input.review.operation
-          any([ operation == "CREATE", operation == "UPDATE" ])
-          operation != "DELETE"
+          is_create_update_or_audit
 
           msg := sprintf("Ingress %v/%v host conflicts with ingress %v/%v: ( '%v' ) & ( '%v' ) = ( '%v' )", [input_ns, input_name, other_ns, other_name, concat("', '",input_paths), concat("', '",other_paths), common_paths[_]])
         }

--- a/katalog/gatekeeper/rules/templates/unique_ingress_template.yml
+++ b/katalog/gatekeeper/rules/templates/unique_ingress_template.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -25,7 +25,7 @@ spec:
             # When the constraint is run by the audit process input.review is not set
             input.review.operation == ""
         }
-        
+
         violation[{"msg": msg}] {
           input.review.kind.kind == "Ingress"
           re_match("^(extensions|networking.k8s.io)$", input.review.kind.group)

--- a/katalog/gatekeeper/rules/templates/unique_service_selector_template.yml
+++ b/katalog/gatekeeper/rules/templates/unique_service_selector_template.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 

--- a/katalog/gatekeeper/rules/templates/unique_service_selector_template.yml
+++ b/katalog/gatekeeper/rules/templates/unique_service_selector_template.yml
@@ -16,6 +16,15 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8suniqueserviceselector
+        is_create_update_or_audit {
+            operation := input.review.operation
+            any([ operation == "CREATE", operation == "UPDATE" ])
+            operation != "DELETE"
+        }
+        is_create_update_or_audit {
+            # When the constraint is run by the audit process input.review is not set
+            input.review.operation == ""
+        }
         make_apiversion(kind) = apiVersion {
           g := kind.group
           v := kind.version
@@ -45,8 +54,6 @@ spec:
           not identical(other, input.review)
           other_selector := flatten_selector(other)
           input_selector == other_selector
-          operation := input.review.operation
-          any([ operation == "CREATE", operation == "UPDATE" ])
-          operation != "DELETE"
+          is_create_update_or_audit
           msg := sprintf("same selector as service <%v> in namespace <%v>", [name, namespace])
         }


### PR DESCRIPTION
Update provided ConstraintTemplates to consider the case that `input.review.operation` is not set when the audit process runs.

Fixes #59
