### PR TITLE
fix: drop audit-chunk-size custom parameter

### DIFF
--- a/katalog/gatekeeper/core/MAINTENANCE.md
+++ b/katalog/gatekeeper/core/MAINTENANCE.md
@@ -2,7 +2,6 @@
 
 1. Check the differences with upstream:
 
-
 ```bash
 curl https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-<UPSTRREAM_VERSION>/deploy/gatekeeper.yaml -o upstream.yaml
 cat ns.yml  crd.yml sa.yml psp.yml rbac.yml secret.yml svc.yml deploy.yml pdb.yml mwh.yml vwh.yml > local.yml 
@@ -24,7 +23,3 @@ Please notice that it is expected that some objects don't have the namespace set
 ## Customizations
 
 - We enable monitoring of metrics by default, so we added some parameters to scrape them.
-
-- The deployment for audit-controller has been customized setting a default value for `--audit-chunk-size` to avoid the audit-controller going into OOM. We've observed this behaviour in serveral clusters, and this seems to fix it.
-
-See [issue #49](https://github.com/sighupio/fury-kubernetes-opa/issues/49)

--- a/katalog/gatekeeper/core/deploy.yml
+++ b/katalog/gatekeeper/core/deploy.yml
@@ -37,10 +37,6 @@ spec:
         - --disable-opa-builtin={http.send}
         - --health-addr=:9090
         - --prometheus-port=8888
-        # setting audit-chunk-size to avoid audit going in OOM.
-        # This is not a default from upstream.
-        # see: https://github.com/sighupio/fury-kubernetes-opa/issues/49
-        - --audit-chunk-size=500
         command:
         - /manager
         env:


### PR DESCRIPTION
The parameter is not needed anymore, since we updated gatekeeper to v3.8 and --audit-chunk-size is set by default to 500 since v3.7

Fixes #66