### PR TITLE
fixes Trigger alert when the Webhook is not responding #64

### DIFF
--- a/katalog/gatekeeper/monitoring/alert-rules.yaml
+++ b/katalog/gatekeeper/monitoring/alert-rules.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Custom set of rules developed by SIGHUP to alert when Gatekeeper webhooks are misbehaving
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: gatekeeper-webhook-rules
+spec:
+  groups:
+    - name: GatekeeperWebhooks
+      rules:
+        - alert: GatekeeperWebhookFailOpenHigh
+          annotations:
+            message: "Gatekeeper is not enforcing {{$labels.type}} requests to the API server."
+            doc: "Gatekeeper is not enforcing {{$labels.type}} requests to the API server because the Kubernetes API server is having trouble contacting the '{{ $labels.name }}' {{$labels.type}} webhook, but the webhook is in Fail open (Ignore) mode."
+          expr: |
+            rate(apiserver_admission_webhook_fail_open_count{name=~".*.gatekeeper.sh"}[1m]) > 0
+          for: 1m
+          labels:
+            severity: warning
+        - alert: GatekeeperWebhookCallError
+          annotations:
+            message: "Kubernetes API server is rejecting all requests because Gatekeeper's webhook '{{ $labels.name }}' is failing for '{{ $labels.operation }}'."
+            doc: "Gatekeeper's '{{ $labels.name }}' webhook is erroring with code {{ $labels.rejection_code }} for '{{ $labels.operation }}' operations and it is configured in Fail mode, effectivly rejecting all the request to the Kubernetes API server."
+          expr: |
+            rate(apiserver_admission_webhook_rejection_count{error_type="calling_webhook_error", name=~".*.gatekeeper.sh"}[1m]) > 0
+          for: 1m
+          labels:
+            severity: critical

--- a/katalog/gatekeeper/monitoring/kustomization.yaml
+++ b/katalog/gatekeeper/monitoring/kustomization.yaml
@@ -10,6 +10,7 @@ namespace: gatekeeper-system
 
 resources:
   - service-monitor.yml
+  - alert-rules.yaml
 
 generatorOptions:
   labels:

--- a/katalog/tests/gatekeeper.sh
+++ b/katalog/tests/gatekeeper.sh
@@ -23,6 +23,7 @@ set -o pipefail
   deploy() {
     sed -i  -e '/# - DELETE/s/# //g' katalog/gatekeeper/core/vwh.yml
     kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.14.2/katalog/prometheus-operator/crd-servicemonitor.yml
+    kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.14.2/katalog/prometheus-operator/crd-rule.yml
     force_apply katalog/gatekeeper/core
   }
   run deploy


### PR DESCRIPTION
Adds alert definitions for when Gatekeeper webhooks are misbehaving:
- WARNING alert when the webhook is in Fail open (Ignore) mode.
- CRITICAL alert when the webhook is in Fail mode.