### PR TITLE
Add Tigera operator namespaces to the default exceptions

### DIFF
--- a/docs/releases/v1.7.1.md
+++ b/docs/releases/v1.7.1.md
@@ -5,6 +5,7 @@ Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](
 This is a patch release including the following changes:
 
 - Updated the provided Grafana dashboard to use the new metrics from Gatekeeper.
+- Added TIgera operator namespaces to the default exemptions in custom rules.
 - Updated Gatekeeper Policy Manager to v1.0.1.
 - Add official support for Kubernetes 1.24
 

--- a/docs/releases/v1.7.1.md
+++ b/docs/releases/v1.7.1.md
@@ -5,7 +5,7 @@ Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](
 This is a patch release including the following changes:
 
 - Updated the provided Grafana dashboard to use the new metrics from Gatekeeper.
-- Added TIgera operator namespaces to the default exemptions in custom rules.
+- Added Tigera operator namespaces to the default exemptions of custom rules.
 - Updated Gatekeeper Policy Manager to v1.0.1.
 - Add official support for Kubernetes 1.24
 

--- a/katalog/gatekeeper/rules/constraints/patches/all-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/all-matches.yml
@@ -11,6 +11,8 @@
       - monitoring
       - ingress-nginx
       - cert-manager
+      - tigera-operator
+      - calico-system
     kinds:
       - apiGroups: ["batch", "extensions", "apps", ""]
         kinds:

--- a/katalog/gatekeeper/rules/constraints/patches/deployment-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/deployment-matches.yml
@@ -11,6 +11,8 @@
       - monitoring
       - ingress-nginx
       - cert-manager
+      - tigera-operator
+      - calico-system
     kinds:
       - apiGroups: ["apps", "extensions"]
         kinds: ["Deployment"]

--- a/katalog/gatekeeper/rules/constraints/patches/ingress-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/ingress-matches.yml
@@ -11,6 +11,8 @@
       - monitoring
       - ingress-nginx
       - cert-manager
+      - tigera-operator
+      - calico-system
     kinds:
       - apiGroups: ["extensions", "networking.k8s.io"]
         kinds: ["Ingress"]

--- a/katalog/gatekeeper/rules/constraints/patches/matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/matches.yml
@@ -11,6 +11,8 @@
       - monitoring
       - ingress-nginx
       - cert-manager
+      - tigera-operator
+      - calico-system
     kinds:
       - apiGroups: ["apps", "extensions"]
         kinds: ["Deployment", "Pods"]


### PR DESCRIPTION
Add to the list of excepted namespaces of the default rules the `tigera-operator` and `calico-system` namespace in use by the Tigera operator introduced in the latest version of the Networking module.