### PR TITLE
fix(rules): add exemption for calico apiserver and vmware CSI namespaces

### DIFF
--- a/katalog/gatekeeper/rules/constraints/patches/all-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/all-matches.yml
@@ -13,6 +13,8 @@
       - cert-manager
       - tigera-operator
       - calico-system
+      - calico-api
+      - vmware-system-csi
     kinds:
       - apiGroups: ["batch", "extensions", "apps", ""]
         kinds:

--- a/katalog/gatekeeper/rules/constraints/patches/all-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/all-matches.yml
@@ -15,6 +15,7 @@
       - calico-system
       - calico-api
       - vmware-system-csi
+      - pomerium
     kinds:
       - apiGroups: ["batch", "extensions", "apps", ""]
         kinds:

--- a/katalog/gatekeeper/rules/constraints/patches/deployment-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/deployment-matches.yml
@@ -13,6 +13,8 @@
       - cert-manager
       - tigera-operator
       - calico-system
+      - calico-api
+      - vmware-system-csi
     kinds:
       - apiGroups: ["apps", "extensions"]
         kinds: ["Deployment"]

--- a/katalog/gatekeeper/rules/constraints/patches/deployment-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/deployment-matches.yml
@@ -15,6 +15,7 @@
       - calico-system
       - calico-api
       - vmware-system-csi
+      - pomerium
     kinds:
       - apiGroups: ["apps", "extensions"]
         kinds: ["Deployment"]

--- a/katalog/gatekeeper/rules/constraints/patches/ingress-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/ingress-matches.yml
@@ -13,6 +13,8 @@
       - cert-manager
       - tigera-operator
       - calico-system
+      - calico-api
+      - vmware-system-csi
     kinds:
       - apiGroups: ["extensions", "networking.k8s.io"]
         kinds: ["Ingress"]

--- a/katalog/gatekeeper/rules/constraints/patches/ingress-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/ingress-matches.yml
@@ -15,6 +15,7 @@
       - calico-system
       - calico-api
       - vmware-system-csi
+      - pomerium
     kinds:
       - apiGroups: ["extensions", "networking.k8s.io"]
         kinds: ["Ingress"]

--- a/katalog/gatekeeper/rules/constraints/patches/matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/matches.yml
@@ -13,6 +13,8 @@
       - cert-manager
       - tigera-operator
       - calico-system
+      - calico-api
+      - vmware-system-csi
     kinds:
       - apiGroups: ["apps", "extensions"]
         kinds: ["Deployment", "Pods"]

--- a/katalog/gatekeeper/rules/constraints/patches/matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/matches.yml
@@ -15,6 +15,7 @@
       - calico-system
       - calico-api
       - vmware-system-csi
+      - pomerium
     kinds:
       - apiGroups: ["apps", "extensions"]
         kinds: ["Deployment", "Pods"]


### PR DESCRIPTION
Add exemptions to the defaults rules for the new namespaces used by the Tigera Operator and VMware CSI in the recent versions:
      - calico-api
      - vmware-system-csi