### PR TITLE
feat(gatekeeper): update to v3.9.2 and prepare v1.7.2 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.7.1
+current_version = 1.7.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-rc{rc}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fury Kubernetes OPA provides the following packages:
 
 | Package                                                | Version  | Description                                                       |
 | ------------------------------------------------------ | -------- | ----------------------------------------------------------------- |
-| [Gatekeeper Core](katalog/gatekeeper/core)             | `v3.9.0` | Gatekeeper deployment, ready to enforce rules.                    |
+| [Gatekeeper Core](katalog/gatekeeper/core)             | `v3.9.2` | Gatekeeper deployment, ready to enforce rules.                    |
 | [Gatekeeper Rules](katalog/gatekeeper/rules)           | `N.A.`   | A set of custom rules to get started with policy enforcement.     |
 | [Gatekeeper Monitoring](katalog/gatekeeper/monitoring) | `N.A.`   | Metrics, alerts and dashboard for monitoring Gatekeeper.          |
 | [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.2` | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
@@ -66,7 +66,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
   - name: opa/gatekeeper
-    version: "v1.7.1"
+    version: "v1.7.2"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -18,6 +18,7 @@
 | v1.6.2                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning:          |                    |
 | v1.7.0                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
 | v1.7.1                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.7.2                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 :white_check_mark: Compatible
 

--- a/docs/releases/v1.7.2.md
+++ b/docs/releases/v1.7.2.md
@@ -4,7 +4,7 @@ Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](
 
 This is a patch release including the following changes:
 
-- Added `calico-apiserver` and `vmware-system-csi` namespaces to the default rules exclusions.
+- Added `pomerium`, `calico-apiserver` and `vmware-system-csi` namespaces to the default rules exclusions.
 - Updated Gatekeeper to v3.9.2 from v3.9.0, fixing a CVE and improving performance.
 
 > 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`

--- a/docs/releases/v1.7.2.md
+++ b/docs/releases/v1.7.2.md
@@ -1,0 +1,29 @@
+# OPA Core Module Release 1.7.2
+
+Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This is a patch release including the following changes:
+
+- Added `calico-apiserver` and `vmware-system-csi` namespaces to the default rules exclusions.
+- Updated Gatekeeper to v3.9.2.
+
+> 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
+
+## Component Images 🚢
+
+| Component                   | Supported Version                                                                     | Previous Version |
+| --------------------------- | ------------------------------------------------------------------------------------- | ---------------- |
+| `gatekeeper`                | [`v3.9.2`](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.9.2)       | `v3.9.0`         |
+| `gatekeeper-policy-manager` | [`v1.0.2`](https://github.com/sighupio/gatekeeper-policy-manager/releases/tag/v1.0.2) | `v1.0.0`         |
+
+> Please refer the individual release notes to get a detailed information on each release.
+
+## Update Guide 🦮
+
+### Process
+
+To upgrade this core module from `v1.7.1` to `v1.7.2`, you need to download this new version, then apply the `kustomize` project. No further action is required.
+
+```bash
+kustomize build katalog/gatekeeper | kubectl apply -f -
+```

--- a/docs/releases/v1.7.2.md
+++ b/docs/releases/v1.7.2.md
@@ -5,7 +5,7 @@ Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](
 This is a patch release including the following changes:
 
 - Added `calico-apiserver` and `vmware-system-csi` namespaces to the default rules exclusions.
-- Updated Gatekeeper to v3.9.2.
+- Updated Gatekeeper to v3.9.2 from v3.9.0, fixing a CVE and improving performance.
 
 > 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
 

--- a/katalog/gatekeeper/README.md
+++ b/katalog/gatekeeper/README.md
@@ -24,7 +24,7 @@ This module can easily be added to your existing Fury setup adding to your `Fury
 bases:
   (...)
   - name: opa/gatekeeper
-    version: "v1.7.1"
+    version: "v1.7.2"
 ```
 
 Once you'll do this, you can then proceed to integrate Gatekeeper into your Kustomize project.

--- a/katalog/gatekeeper/core/MAINTENANCE.md
+++ b/katalog/gatekeeper/core/MAINTENANCE.md
@@ -31,7 +31,7 @@ diff the generated `local.yaml` with the `upstream.yaml` file and port the neede
 
 Please notice that it is expected that some objects don't have the namespace set as in upstream, this is because the namespace is set with Kustomize.
 
-2. Sync the new image to our registry by updateing the [OPA iamges.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/opa/images.yml).
+2. Sync the new image to our registry by updating the [OPA images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/opa/images.yml).
 
 3. Update the `kustomization.yaml` file with the new version in the image tag.
 

--- a/katalog/gatekeeper/core/MAINTENANCE.md
+++ b/katalog/gatekeeper/core/MAINTENANCE.md
@@ -1,11 +1,23 @@
 # Gatekepeer Package Maintenance
 
-1. Check the differences with upstream:
+1. Check the differences with upstream manifests:
 
 ```bash
+# Assuming ${PWD} == the root of the project
 export GATEKEEPER_VERSION=3.9
 curl https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-${GATEKEEPER_VERSION}/deploy/gatekeeper.yaml -o upstream.yaml
-cat ns.yml  crd.yml sa.yml psp.yml rbac.yml secret.yml svc.yml deploy.yml pdb.yml mwh.yml vwh.yml > local.yml 
+cat katalog/gatekeeper/core/ns.yml \
+    katalog/gatekeeper/core/crd.yml \
+    katalog/gatekeeper/core/sa.yml \
+    katalog/gatekeeper/core/psp.yml \
+    katalog/gatekeeper/core/rbac.yml \
+    katalog/gatekeeper/core/secret.yml \
+    katalog/gatekeeper/core/svc.yml \
+    katalog/gatekeeper/core/deploy.yml \
+    katalog/gatekeeper/core/pdb.yml \
+    katalog/gatekeeper/core/mwh.yml \
+    katalog/gatekeeper/core/vwh.yml \
+    > local.yml 
 ```
 
 > You could generate the output with `kustomize build .` also, but `kustomize` changes all the indentation and word wrapping of the original files, so you won't be able to do the diff against its output.
@@ -13,11 +25,11 @@ cat ns.yml  crd.yml sa.yml psp.yml rbac.yml secret.yml svc.yml deploy.yml pdb.ym
 Replace `GATEKEEPER_VERSION` with the upstream version you want to compare with. Example: `3.9`.
 You can use the link from the [installation instructions](https://open-policy-agent.github.io/gatekeeper/website/docs/install#deploying-a-release-using-prebuilt-image).
 
-diff the generated `local.yaml` with `upstream.yaml` and port the needed differences.
+diff the generated `local.yaml` with the `upstream.yaml` file and port the needed differences to the corresponding file.
 
 > You can also diff a single file to `upstream.yaml` to port more easily the differences.
 
-Please notice that it is expected that some objects don't have the namespace set as in upstream, thi is because the namespace is set with kustomize.
+Please notice that it is expected that some objects don't have the namespace set as in upstream, this is because the namespace is set with Kustomize.
 
 2. Sync the new image to our registry by updateing the [OPA iamges.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/opa/images.yml).
 
@@ -26,3 +38,4 @@ Please notice that it is expected that some objects don't have the namespace set
 ## Customizations
 
 - We enable monitoring of metrics by default, so we added some parameters to scrape them.
+- We delete the namesapce from resources definitions, the namespace is set by Kustomize.

--- a/katalog/gatekeeper/core/kustomization.yaml
+++ b/katalog/gatekeeper/core/kustomization.yaml
@@ -24,4 +24,4 @@ resources:
 images:
   - name: openpolicyagent/gatekeeper
     newName: registry.sighup.io/fury/openpolicyagent/gatekeeper
-    newTag: v3.9.0
+    newTag: v3.9.2


### PR DESCRIPTION
- update Gatekeeper to v3.9.2
- prepare for release v1.7.2 of the module

Changes in upstream ([v3.9.1](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.9.1) and [v3.9.2](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.9.2))
- They've updated some internal lib and fixed a CVE, with no major changes from 3.9.0 (the version we were including)
- There are no changes to the manifests in upstream