### PR TITLE
fix(monitoring): fix description field in alertrules

### DIFF
--- a/katalog/gatekeeper/monitoring/alert-rules.yaml
+++ b/katalog/gatekeeper/monitoring/alert-rules.yaml
@@ -17,7 +17,7 @@ spec:
       rules:
         - alert: GatekeeperWebhookFailOpenHigh
           annotations:
-            message: "Gatekeeper is not enforcing {{$labels.type}} requests to the API server."
+            description: "Gatekeeper is not enforcing {{$labels.type}} requests to the API server."
             doc: "Gatekeeper is not enforcing {{$labels.type}} requests to the API server because the Kubernetes API server is having trouble contacting the '{{ $labels.name }}' {{$labels.type}} webhook, but the webhook is in Fail open (Ignore) mode."
           expr: |
             rate(apiserver_admission_webhook_fail_open_count{name=~".*.gatekeeper.sh"}[5m]) > 0
@@ -26,7 +26,7 @@ spec:
             severity: warning
         - alert: GatekeeperWebhookCallError
           annotations:
-            message: "Kubernetes API server is rejecting all requests because Gatekeeper's webhook '{{ $labels.name }}' is failing for '{{ $labels.operation }}'."
+            description: "Kubernetes API server is rejecting all requests because Gatekeeper's webhook '{{ $labels.name }}' is failing for '{{ $labels.operation }}'."
             doc: "Gatekeeper's '{{ $labels.name }}' webhook is erroring with code {{ $labels.rejection_code }} for '{{ $labels.operation }}' operations and it is configured in Fail mode, effectivly rejecting all the request to the Kubernetes API server."
           expr: |
             rate(apiserver_admission_webhook_rejection_count{error_type="calling_webhook_error", name=~".*.gatekeeper.sh"}[5m]) > 0


### PR DESCRIPTION
Align the field used to describe the alert with what we are using in the rest of the alerts and in the AlertManager template for the Slack notifications.