### PR TITLE
fix(rules): delete references to deprecated Ingress API

### DIFF
--- a/katalog/gatekeeper/rules/config/config.yml
+++ b/katalog/gatekeeper/rules/config/config.yml
@@ -10,12 +10,6 @@ metadata:
 spec:
   sync:
     syncOnly:
-      - group: "extensions"
-        version: "v1beta1"
-        kind: "Ingress"
-      - group: "networking.k8s.io"
-        version: "v1beta1"
-        kind: "Ingress"
       - group: "networking.k8s.io"
         version: "v1"
         kind: "Ingress"

--- a/katalog/gatekeeper/rules/templates/unique_ingress_template.yml
+++ b/katalog/gatekeeper/rules/templates/unique_ingress_template.yml
@@ -31,7 +31,7 @@ spec:
 
         violation[{"msg": msg}] {
           input.review.kind.kind == "Ingress"
-          re_match("^(extensions|networking.k8s.io)$", input.review.kind.group)
+          input.review.kind.group == "networking.k8s.io"
           input.review.kind.version == "v1"
 
           some i


### PR DESCRIPTION
- delete sync of deprecated APIs for Ingress
- adjust duplicated ingress checks rule

tested E2E test locally and are passing with K8s 1.24.0.

Fixes #87