### PR TITLE
prepare for release v1.7.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.7.2
+current_version = 1.7.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-rc{rc}

--- a/.drone.yml
+++ b/.drone.yml
@@ -78,6 +78,7 @@ trigger:
   ref:
     include:
       - refs/heads/master
+      - refs/heads/main
       - refs/tags/**
 
 steps:
@@ -177,6 +178,7 @@ trigger:
   ref:
     include:
       - refs/heads/master
+      - refs/heads/main
       - refs/tags/**
 
 steps:
@@ -276,6 +278,7 @@ trigger:
   ref:
     include:
       - refs/heads/master
+      - refs/heads/main
       - refs/tags/**
 
 steps:
@@ -375,6 +378,7 @@ trigger:
   ref:
     include:
       - refs/heads/master
+      - refs/heads/main
       - refs/tags/**
 
 steps:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
   - name: opa/gatekeeper
-    version: "v1.7.2"
+    version: "v1.7.3"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -164,7 +164,7 @@ Notice that the alert for when the Gatekeeper webhook is in `Ignore` mode (the d
 [kfd-repo]: https://github.com/sighupio/fury-distribution
 [kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
 [kfd-docs]: https://docs.kubernetesfury.com/docs/distribution/
-[compatibility-matrix]: https://github.com/sighupio/fury-kubernetes-opa/blob/master/docs/COMPATIBILITY_MATRIX.md
+[compatibility-matrix]: https://github.com/sighupio/fury-kubernetes-opa/blob/main/docs/COMPATIBILITY_MATRIX.md
 
 <!-- </KFD-DOCS> -->
 

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -19,6 +19,7 @@
 | v1.7.0                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
 | v1.7.1                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | v1.7.2                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.7.3                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 :white_check_mark: Compatible
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -74,7 +74,7 @@ patch release):
 ```bash
 $ make bump-patch
 Making a patch tag
-$ git push --tags origin master
+$ git push --tags origin main
 # This should trigger the drone pipeline to publish the new release with the release notes from the file created.
 ```
 

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -6,7 +6,7 @@ Changes between `1.0.2` and this release: `1.1.0`
 
 - Add metrics port to service
 - Add service monitor definition for Prometheus scraping
-- [prometheus-operator](https://github.com/sighupio/fury-kubernetes-monitoring/tree/master/katalog/prometheus-operator)
+- [prometheus-operator](https://github.com/sighupio/fury-kubernetes-monitoring/tree/main/katalog/prometheus-operator)
 from the [Fury Monitoring Module](https://github.com/sighupio/fury-kubernetes-monitoring) is now required by
 [Service monitor](./katalog/gatekeeper/core/service-monitor.yml) to export metrics to Prometheus (it can be disabled).
 - Set default replica count to 1 due to HA not being supported upstream

--- a/docs/releases/v1.7.3.md
+++ b/docs/releases/v1.7.3.md
@@ -1,0 +1,29 @@
+# OPA Core Module Release 1.7.3
+
+Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This is a patch release including the following changes:
+
+- Removed references to deprecated Ingress API in Gatekeeper's config and custom rules (#88)
+- Updated documentation
+
+> 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
+
+## Component Images 🚢
+
+| Component                   | Supported Version                                                                     | Previous Version |
+| --------------------------- | ------------------------------------------------------------------------------------- | ---------------- |
+| `gatekeeper`                | [`v3.9.2`](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.9.2)       | No update        |
+| `gatekeeper-policy-manager` | [`v1.0.2`](https://github.com/sighupio/gatekeeper-policy-manager/releases/tag/v1.0.2) | No update        |
+
+> Please refer the individual release notes to get a detailed information on each release.
+
+## Update Guide 🦮
+
+### Process
+
+To upgrade this core module from `v1.7.2` to `v1.7.3`, you need to download this new version, then apply the `kustomize` project. No further action is required.
+
+```bash
+kustomize build katalog/gatekeeper | kubectl apply -f -
+```

--- a/docs/releases/v1.7.3.md
+++ b/docs/releases/v1.7.3.md
@@ -7,7 +7,7 @@ This is a patch release including the following changes:
 - Removed references to deprecated Ingress API in Gatekeeper's config and custom rules ([#88](https://github.com/sighupio/fury-kubernetes-opa/pull/88))
 - Updated documentation
 
-> 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
+> 💡 Please refer to the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
 
 ## Component Images 🚢
 

--- a/docs/releases/v1.7.3.md
+++ b/docs/releases/v1.7.3.md
@@ -4,7 +4,7 @@ Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](
 
 This is a patch release including the following changes:
 
-- Removed references to deprecated Ingress API in Gatekeeper's config and custom rules (#88)
+- Removed references to deprecated Ingress API in Gatekeeper's config and custom rules ([#88](https://github.com/sighupio/fury-kubernetes-opa/pull/88))
 - Updated documentation
 
 > 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`

--- a/katalog/gatekeeper/README.md
+++ b/katalog/gatekeeper/README.md
@@ -24,7 +24,7 @@ This module can easily be added to your existing Fury setup adding to your `Fury
 bases:
   (...)
   - name: opa/gatekeeper
-    version: "v1.7.2"
+    version: "v1.7.3"
 ```
 
 Once you'll do this, you can then proceed to integrate Gatekeeper into your Kustomize project.


### PR DESCRIPTION
Add documentation for release v1.7.3
Fixed some old references to the master branch that got renamed to main