### PR TITLE
chore(ci): deprecate deprek8n in favor of fairwinds pluto

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -51,13 +51,14 @@ steps:
     commands:
       - kustomize build katalog/gatekeeper > gatekeeper.yml
 
-  - name: deprek8ion
-    image: eu.gcr.io/swade1987/deprek8ion:1.1.34
+  - name: check-deprecated-apis
+    image: us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
     pull: always
     depends_on:
       - render
     commands:
-      - /conftest test -p /policies gatekeeper.yml
+      # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
+      - /pluto detect gatekeeper.yml --target-versions=k8s=v1.24.0 --ignore-deprecations
 
 ---
 name: e2e-kubernetes-1.21


### PR DESCRIPTION
deprek8n is not maintained anymore. Switching to Fairwinds Pluto to check for removed Kubernetes API usage in our manifests.

I'm adding check for Kubernetes 1.24.0 and NOT failing when finding APIs that are going to be deprecated in next versions, fail the step only when using APIs that have been removed.

See the run for this PR branch as an example: https://ci.sighup.io/sighupio/fury-kubernetes-opa/563/2/4