### PR TITLE
feat: put dashboards in "OPA" grafana folder

### DIFF
--- a/katalog/gatekeeper/monitoring/kustomization.yaml
+++ b/katalog/gatekeeper/monitoring/kustomization.yaml
@@ -15,6 +15,8 @@ resources:
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "OPA"
   disableNameSuffixHash: true
 
 configMapGenerator:


### PR DESCRIPTION
Add annotation to put the module's Grafana dashboards inside the "OPA" folder for better organization.