### PR TITLE
support for Kubernetes 1.26

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,10 +8,10 @@ type: docker
 
 steps:
   - name: check
-    image: docker.io/library/golang:1.16
+    image: docker.io/library/golang:1.20
     pull: always
     commands:
-      - go get -u github.com/google/addlicense
+      - go install github.com/google/addlicense@v1.1.1
       - addlicense -c "SIGHUP s.r.l" -v -l bsd -y "2017-present" --check .
 
 ---
@@ -44,7 +44,7 @@ steps:
       - clone
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.20.7_3.8.7_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
     pull: always
     depends_on:
       - clone
@@ -59,106 +59,6 @@ steps:
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
       - /pluto detect gatekeeper.yml --target-versions=k8s=v1.25.0 --ignore-deprecations
-
----
-name: e2e-kubernetes-1.22
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-node:
-  runner: internal
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/heads/master
-      - refs/heads/main
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.0
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [clone]
-    settings:
-      action: custom-cluster-122
-      pipeline_id: cluster-122
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: "1.22.0"
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.22.0_3.8.7_2.4.1
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [init]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-122
-      - bats -t katalog/tests/gatekeeper.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.0
-    pull: always
-    depends_on: [e2e]
-    settings:
-      action: destroy
-      pipeline_id: cluster-122
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: shared
-    temp: {}
 
 ---
 name: e2e-kubernetes-1.23
@@ -180,6 +80,7 @@ trigger:
     include:
       - refs/heads/master
       - refs/heads/main
+      - refs/heads/develop
       - refs/tags/**
 
 steps:
@@ -280,6 +181,7 @@ trigger:
     include:
       - refs/heads/master
       - refs/heads/main
+      - refs/heads/develop
       - refs/tags/**
 
 steps:
@@ -379,6 +281,7 @@ trigger:
     include:
       - refs/heads/master
       - refs/heads/main
+      - refs/heads/develop
       - refs/tags/**
 
 steps:
@@ -459,6 +362,106 @@ steps:
 volumes:
   - name: shared
     temp: {}
+---
+name: e2e-kubernetes-1.26
+kind: pipeline
+type: docker
+
+depends_on:
+  - policeman
+
+node:
+  runner: internal
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/master
+      - refs/heads/main
+      - refs/heads/develop
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v1.26.3
+    pull: always
+    volumes:
+      - name: shared
+        path: /shared
+    depends_on: [clone]
+    settings:
+      action: custom-cluster-126
+      pipeline_id: cluster-126
+      local_kind_config_path: katalog/tests/kind/config.yml
+      cluster_version: "1.26.3"
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+
+  - name: e2e
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    volumes:
+      - name: shared
+        path: /shared
+    depends_on: [init]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-126
+      - bats -t katalog/tests/gatekeeper.sh
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v1.26.3
+    pull: always
+    depends_on: [e2e]
+    settings:
+      action: destroy
+      pipeline_id: cluster-126
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: shared
+    temp: {}
 
 ---
 name: release
@@ -466,10 +469,10 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.22
   - e2e-kubernetes-1.23
   - e2e-kubernetes-1.24
   - e2e-kubernetes-1.25
+  - e2e-kubernetes-1.26
 
 platform:
   os: linux
@@ -481,17 +484,6 @@ trigger:
       - refs/tags/**
 
 steps:
-  - name: prepare-canonical-json
-    image: registry.sighup.io/poc/fury-repo-automations:v0.0.3
-    pull: always
-    depends_on: [clone]
-    commands:
-      - spock module-json -m=fury-kubernetes-opa -r=False -v=${DRONE_TAG}
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
   - name: prepare-tar-gz
     image: alpine:latest
     pull: always
@@ -518,7 +510,6 @@ steps:
     image: plugins/github-release
     pull: always
     depends_on:
-      - prepare-canonical-json
       - prepare-tar-gz
       - prepare-release-notes
     settings:
@@ -527,7 +518,6 @@ steps:
       file_exists: overwrite
       files:
         - fury-kubernetes-opa-${DRONE_TAG}.tar.gz
-        - fury-kubernetes-opa-canonical-definition-${DRONE_TAG}.json
       prerelease: true
       overwrite: true
       title: "Preview ${DRONE_TAG}"
@@ -544,7 +534,6 @@ steps:
     image: plugins/github-release
     pull: always
     depends_on:
-      - prepare-canonical-json
       - prepare-tar-gz
       - prepare-release-notes
     settings:
@@ -553,7 +542,6 @@ steps:
       file_exists: overwrite
       files:
         - fury-kubernetes-opa-${DRONE_TAG}.tar.gz
-        - fury-kubernetes-opa-canonical-definition-${DRONE_TAG}.json
       prerelease: false
       overwrite: true
       title: "Release ${DRONE_TAG}"

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Fury Kubernetes OPA provides the following packages:
 
 | Package                                                | Version   | Description                                                       |
 | ------------------------------------------------------ | --------- | ----------------------------------------------------------------- |
-| [Gatekeeper Core](katalog/gatekeeper/core)             | `v3.11.0` | Gatekeeper deployment, ready to enforce rules.                    |
+| [Gatekeeper Core](katalog/gatekeeper/core)             | `v3.12.0` | Gatekeeper deployment, ready to enforce rules.                    |
 | [Gatekeeper Rules](katalog/gatekeeper/rules)           | `N.A.`    | A set of custom rules to get started with policy enforcement.     |
 | [Gatekeeper Monitoring](katalog/gatekeeper/monitoring) | `N.A.`    | Metrics, alerts and dashboard for monitoring Gatekeeper.          |
-| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.3`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
+| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.4`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
 
 Click on each package name to see its full documentation.
 
@@ -40,10 +40,10 @@ Click on each package name to see its full documentation.
 
 | Kubernetes Version |   Compatibility    | Notes            |
 | ------------------ | :----------------: | ---------------- |
-| `1.22.x`           | :white_check_mark: | No known issues  |
 | `1.23.x`           | :white_check_mark: | No known issues. |
 | `1.24.x`           | :white_check_mark: | No known issues. |
 | `1.25.x`           | :white_check_mark: | No known issues. |
+| `1.26.x`           | :white_check_mark: | No known issues  |
 
 Check the [compatibility matrix][compatibility-matrix] for additional information on previous releases of the module.
 
@@ -54,7 +54,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 | Tool                                    | Version    | Description                                                                                                                                                    |
 | --------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [furyctl][furyctl-repo]                 | `>=0.6.0`  | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
-| [kustomize][kustomize-repo]             | `>=3.5.0`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
+| [kustomize][kustomize-repo]             | `>=3.5.3`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
 | [KFD Monitoring Module][kfd-monitoring] | `>v1.10.0` | Expose metrics to Prometheus *(optional)* and use Grafana Dashboards.                                                                                          |
 
 > You can comment out the service monitor in the [kustomization.yaml][core-kustomization] file if you don't want to install the monitoring module.

--- a/katalog/gatekeeper/core/MAINTENANCE.md
+++ b/katalog/gatekeeper/core/MAINTENANCE.md
@@ -1,10 +1,10 @@
-# Gatekepeer Package Maintenance
+# Gatekeeper Package Maintenance
 
 1. Check the differences with upstream manifests:
 
 ```bash
 # Assuming ${PWD} == the root of the project
-export GATEKEEPER_VERSION=3.11
+export GATEKEEPER_VERSION=3.12
 curl https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-${GATEKEEPER_VERSION}/deploy/gatekeeper.yaml -o upstream.yaml
 cat katalog/gatekeeper/core/ns.yml \
     katalog/gatekeeper/core/crd.yml \
@@ -16,7 +16,7 @@ cat katalog/gatekeeper/core/ns.yml \
     katalog/gatekeeper/core/pdb.yml \
     katalog/gatekeeper/core/mwh.yml \
     katalog/gatekeeper/core/vwh.yml \
-    > local.yml 
+    > local.yml
 ```
 
 > You could generate the output with `kustomize build .` also, but `kustomize` changes all the indentation and word wrapping of the original files, so you won't be able to do the diff against its output.
@@ -37,4 +37,4 @@ Please notice that it is expected that some objects don't have the namespace set
 ## Customizations
 
 - We enable monitoring of metrics by default, so we added some parameters to scrape them.
-- We delete the namesapce from resources definitions, the namespace is set by Kustomize.
+- We delete the namespace from resources definitions, the namespace is set by Kustomize.

--- a/katalog/gatekeeper/core/crd.yml
+++ b/katalog/gatekeeper/core/crd.yml
@@ -768,6 +768,244 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.10.0
   labels:
     gatekeeper.sh/system: "yes"
+  name: assignimage.mutations.gatekeeper.sh
+spec:
+  group: mutations.gatekeeper.sh
+  names:
+    kind: AssignImage
+    listKind: AssignImageList
+    plural: assignimage
+    singular: assignimage
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: AssignImage is the Schema for the assignimage API.
+          properties:
+            apiVersion:
+              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              properties:
+                name:
+                  maxLength: 63
+                  type: string
+              type: object
+            spec:
+              description: AssignImageSpec defines the desired state of AssignImage.
+              properties:
+                applyTo:
+                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  items:
+                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    properties:
+                      groups:
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                      versions:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                location:
+                  description: "Location describes the path to be mutated, for example: `spec.containers[name: main].image`."
+                  type: string
+                match:
+                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
+                  properties:
+                    excludedNamespaces:
+                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      items:
+                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
+                        pattern: ^(\*|\*-)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        type: string
+                      type: array
+                    kinds:
+                      items:
+                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        properties:
+                          apiGroups:
+                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            items:
+                              type: string
+                            type: array
+                          kinds:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    labelSelector:
+                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    name:
+                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
+                      pattern: ^(\*|\*-)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      type: string
+                    namespaceSelector:
+                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    namespaces:
+                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      items:
+                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
+                        pattern: ^(\*|\*-)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        type: string
+                      type: array
+                    scope:
+                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      type: string
+                    source:
+                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      enum:
+                        - All
+                        - Generated
+                        - Original
+                      type: string
+                  type: object
+                parameters:
+                  description: Parameters define the behavior of the mutator.
+                  properties:
+                    assignDomain:
+                      description: AssignDomain sets the domain component on an image string. The trailing slash should not be included.
+                      type: string
+                    assignPath:
+                      description: AssignPath sets the domain component on an image string.
+                      type: string
+                    assignTag:
+                      description: AssignImage sets the image component on an image string. It must start with a `:` or `@`.
+                      type: string
+                    pathTests:
+                      items:
+                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        properties:
+                          condition:
+                            description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                            enum:
+                              - MustExist
+                              - MustNotExist
+                            type: string
+                          subPath:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            status:
+              description: AssignImageStatus defines the observed state of AssignImage.
+              properties:
+                byPod:
+                  items:
+                    description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                    properties:
+                      enforced:
+                        type: boolean
+                      errors:
+                        items:
+                          description: MutatorError represents a single error caught while adding a mutator to a system.
+                          properties:
+                            message:
+                              type: string
+                            type:
+                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              type: string
+                          required:
+                            - message
+                          type: object
+                        type: array
+                      id:
+                        type: string
+                      mutatorUID:
+                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        type: integer
+                      operations:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    gatekeeper.sh/system: "yes"
   name: assignmetadata.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh
@@ -802,7 +1040,7 @@ spec:
                 location:
                   type: string
                 match:
-                  description: Match selects objects to apply mutations to.
+                  description: Match selects which objects are in scope.
                   properties:
                     excludedNamespaces:
                       description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
@@ -1013,7 +1251,7 @@ spec:
                 location:
                   type: string
                 match:
-                  description: Match selects objects to apply mutations to.
+                  description: Match selects which objects are in scope.
                   properties:
                     excludedNamespaces:
                       description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
@@ -1224,7 +1462,7 @@ spec:
                 location:
                   type: string
                 match:
-                  description: Match selects objects to apply mutations to.
+                  description: Match selects which objects are in scope.
                   properties:
                     excludedNamespaces:
                       description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
@@ -1662,7 +1900,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   labels:
     gatekeeper.sh/system: "yes"
   name: constrainttemplates.templates.gatekeeper.sh
@@ -1721,6 +1959,24 @@ spec:
                 targets:
                   items:
                     properties:
+                      code:
+                        description: The source code options for the constraint template. "Rego" can only be specified in one place (either here or in the "rego" field)
+                        items:
+                          properties:
+                            engine:
+                              description: 'The engine used to evaluate the code. Example: "Rego". Required.'
+                              type: string
+                            source:
+                              description: The source code for the template. Required.
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                            - engine
+                            - source
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - engine
+                        x-kubernetes-list-type: map
                       libs:
                         items:
                           type: string
@@ -1816,6 +2072,24 @@ spec:
                 targets:
                   items:
                     properties:
+                      code:
+                        description: The source code options for the constraint template. "Rego" can only be specified in one place (either here or in the "rego" field)
+                        items:
+                          properties:
+                            engine:
+                              description: 'The engine used to evaluate the code. Example: "Rego". Required.'
+                              type: string
+                            source:
+                              description: The source code for the template. Required.
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                            - engine
+                            - source
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - engine
+                        x-kubernetes-list-type: map
                       libs:
                         items:
                           type: string
@@ -1911,6 +2185,24 @@ spec:
                 targets:
                   items:
                     properties:
+                      code:
+                        description: The source code options for the constraint template. "Rego" can only be specified in one place (either here or in the "rego" field)
+                        items:
+                          properties:
+                            engine:
+                              description: 'The engine used to evaluate the code. Example: "Rego". Required.'
+                              type: string
+                            source:
+                              description: The source code for the template. Required.
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                            - engine
+                            - source
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - engine
+                        x-kubernetes-list-type: map
                       libs:
                         items:
                           type: string
@@ -2783,7 +3075,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   labels:
     gatekeeper.sh/system: "yes"
   name: providers.externaldata.gatekeeper.sh
@@ -2822,12 +3114,12 @@ spec:
                   description: Timeout is the timeout when querying the provider.
                   type: integer
                 url:
-                  description: URL is the url for the provider. URL is prefixed with http:// or https://.
+                  description: URL is the url for the provider. URL is prefixed with https://.
                   type: string
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
     - name: v1beta1
       schema:
         openAPIV3Schema:
@@ -2851,9 +3143,9 @@ spec:
                   description: Timeout is the timeout when querying the provider.
                   type: integer
                 url:
-                  description: URL is the url for the provider. URL is prefixed with http:// or https://.
+                  description: URL is the url for the provider. URL is prefixed with https://.
                   type: string
               type: object
           type: object
       served: true
-      storage: false
+      storage: true

--- a/katalog/gatekeeper/core/kustomization.yaml
+++ b/katalog/gatekeeper/core/kustomization.yaml
@@ -23,4 +23,4 @@ resources:
 images:
   - name: openpolicyagent/gatekeeper
     newName: registry.sighup.io/fury/openpolicyagent/gatekeeper
-    newTag: v3.11.0
+    newTag: v3.12.0

--- a/katalog/gatekeeper/core/rbac.yml
+++ b/katalog/gatekeeper/core/rbac.yml
@@ -38,6 +38,13 @@ metadata:
   name: gatekeeper-manager-role
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
       - "*"
     resources:
       - "*"

--- a/katalog/gatekeeper/gpm/kustomization.yaml
+++ b/katalog/gatekeeper/gpm/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: quay.io/sighup/gatekeeper-policy-manager
     newName: registry.sighup.io/fury/gatekeeper-policy-manager
-    newTag: v1.0.3
+    newTag: v1.0.4

--- a/katalog/tests/gatekeeper-manifests/mutation.yaml
+++ b/katalog/tests/gatekeeper-manifests/mutation.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+#Sample Mutation that adds an annotation
+apiVersion: mutations.gatekeeper.sh/v1
+kind: AssignMetadata
+metadata:
+  name: demo-annotation-owner
+spec:
+  match:
+    scope: Namespaced
+    name: deployment-*
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Deployment"]
+  location: "metadata.annotations.owner"
+  parameters:
+    assign:
+      value: "sighup"

--- a/katalog/tests/gatekeeper.sh
+++ b/katalog/tests/gatekeeper.sh
@@ -165,7 +165,7 @@ set -o pipefail
 @test "[CHECK] Check deployment has been mutated" {
   info
   deploy() {
-    kubectl get deployment -n default deployment-allowed -ojsonpath={.metadata.annotations.owner}
+    kubectl get deployment -n default deployment-allowed -ojsonpath="{.metadata.annotations.owner}"
   }
   run deploy
   echo "${output}"
@@ -176,7 +176,7 @@ set -o pipefail
 @test "[CHECK] Check deployment has NOT been mutated" {
   info
   deploy() {
-    kubectl get deployment -n kube-system deployment-allowed-ns -ojsonpath={.metadata.annotations.owner}
+    kubectl get deployment -n kube-system deployment-allowed-ns -ojsonpath="{.metadata.annotations.owner}"
   }
   run deploy
   echo "${output}"


### PR DESCRIPTION
- add k8s 1.26 support to CI
- remove k8s 1.22 support from CI
- add triggers for `develop` branch to CI
- update OPA Gatekeeper to v3.12
- update GPM to v1.0.4
- update e2e tests to include mutations
- update docs