### PR TITLE
feat: bump GPM to v1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fury Kubernetes OPA provides the following packages:
 | [Gatekeeper Core](katalog/gatekeeper/core)             | `v3.12.0` | Gatekeeper deployment, ready to enforce rules.                    |
 | [Gatekeeper Rules](katalog/gatekeeper/rules)           | `N.A.`    | A set of custom rules to get started with policy enforcement.     |
 | [Gatekeeper Monitoring](katalog/gatekeeper/monitoring) | `N.A.`    | Metrics, alerts and dashboard for monitoring Gatekeeper.          |
-| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.7`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
+| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.9`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
 
 Click on each package name to see its full documentation.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fury Kubernetes OPA provides the following packages:
 | [Gatekeeper Core](katalog/gatekeeper/core)             | `v3.12.0` | Gatekeeper deployment, ready to enforce rules.                    |
 | [Gatekeeper Rules](katalog/gatekeeper/rules)           | `N.A.`    | A set of custom rules to get started with policy enforcement.     |
 | [Gatekeeper Monitoring](katalog/gatekeeper/monitoring) | `N.A.`    | Metrics, alerts and dashboard for monitoring Gatekeeper.          |
-| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.6`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
+| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.7`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
 
 Click on each package name to see its full documentation.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fury Kubernetes OPA provides the following packages:
 | [Gatekeeper Core](katalog/gatekeeper/core)             | `v3.12.0` | Gatekeeper deployment, ready to enforce rules.                    |
 | [Gatekeeper Rules](katalog/gatekeeper/rules)           | `N.A.`    | A set of custom rules to get started with policy enforcement.     |
 | [Gatekeeper Monitoring](katalog/gatekeeper/monitoring) | `N.A.`    | Metrics, alerts and dashboard for monitoring Gatekeeper.          |
-| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.4`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
+| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.5`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
 
 Click on each package name to see its full documentation.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fury Kubernetes OPA provides the following packages:
 | [Gatekeeper Core](katalog/gatekeeper/core)             | `v3.12.0` | Gatekeeper deployment, ready to enforce rules.                    |
 | [Gatekeeper Rules](katalog/gatekeeper/rules)           | `N.A.`    | A set of custom rules to get started with policy enforcement.     |
 | [Gatekeeper Monitoring](katalog/gatekeeper/monitoring) | `N.A.`    | Metrics, alerts and dashboard for monitoring Gatekeeper.          |
-| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.5`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
+| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.0.6`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper. |
 
 Click on each package name to see its full documentation.
 

--- a/katalog/gatekeeper/gpm/kustomization.yaml
+++ b/katalog/gatekeeper/gpm/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: quay.io/sighup/gatekeeper-policy-manager
     newName: registry.sighup.io/fury/gatekeeper-policy-manager
-    newTag: v1.0.5
+    newTag: v1.0.6

--- a/katalog/gatekeeper/gpm/kustomization.yaml
+++ b/katalog/gatekeeper/gpm/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: quay.io/sighup/gatekeeper-policy-manager
     newName: registry.sighup.io/fury/gatekeeper-policy-manager
-    newTag: v1.0.4
+    newTag: v1.0.5

--- a/katalog/gatekeeper/gpm/kustomization.yaml
+++ b/katalog/gatekeeper/gpm/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: quay.io/sighup/gatekeeper-policy-manager
     newName: registry.sighup.io/fury/gatekeeper-policy-manager
-    newTag: v1.0.7
+    newTag: v1.0.9

--- a/katalog/gatekeeper/gpm/kustomization.yaml
+++ b/katalog/gatekeeper/gpm/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
   - name: quay.io/sighup/gatekeeper-policy-manager
     newName: registry.sighup.io/fury/gatekeeper-policy-manager
-    newTag: v1.0.6
+    newTag: v1.0.7


### PR DESCRIPTION
Bump GPM to v1.0.9 that includes several fixes to OIDC authentication, multicluster view, and updated dependencies.

Fixes https://github.com/sighupio/product-management/issues/283

Related image sync PR:
- https://github.com/sighupio/fury-distribution-container-image-sync/pull/174