### PR TITLE
refactor(ci): use kind for e2e test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,25 +2,31 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-name: license
+name: Check License Header Presence
 kind: pipeline
 type: docker
 
+clone:
+  depth: 1
+
 steps:
-  - name: check
+  - name: Check License Header Presence
     image: docker.io/library/golang:1.20
     pull: always
     commands:
       - go install github.com/google/addlicense@v1.1.1
-      - addlicense -c "SIGHUP s.r.l" -v -l bsd -y "2017-present" --check .
+      - addlicense -c "SIGHUP s.r.l" -v -l bsd --check .
 
 ---
-name: policeman
+name: Linting
 kind: pipeline
 type: docker
 
+clone:
+  depth: 1
+
 depends_on:
-  - license
+  - Check License Header Presence
 
 platform:
   os: linux
@@ -43,7 +49,7 @@ steps:
     depends_on:
       - clone
 
-  - name: render
+  - name: Render Manifests
     image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
     pull: always
     depends_on:
@@ -52,26 +58,34 @@ steps:
       - kustomize build katalog/gatekeeper > gatekeeper.yml
       - kustomize build katalog/kyverno > kyverno.yml
 
-  - name: check-deprecated-apis
+  - &check-deprecated-apis
+    name: check-deprecated-apis
     image: us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
     pull: always
     depends_on:
-      - render
+      - Render Manifests
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect gatekeeper.yml --target-versions=k8s=v1.27.0 --ignore-deprecations
-      - /pluto detect kyverno.yml --target-versions=k8s=v1.27.0 --ignore-deprecations
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.29.0
+
+    environment:
+      KUBERNETES_MANIFESTS: gatekeeper.yml
+
+  - <<: *check-deprecated-apis
+    name: check-deprecated-apis-kyverno
+    environment:
+      KUBERNETES_MANIFESTS: kyverno.yml
 
 ---
-name: e2e-kubernetes-1.25-gatekeeper
+name: E2E Tests Kubernetes 1.26
 kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - Linting
 
-node:
-  runner: internal
+clone:
+  depth: 1
 
 platform:
   os: linux
@@ -80,406 +94,75 @@ platform:
 trigger:
   ref:
     include:
-      - refs/heads/master
       - refs/heads/main
-      - refs/heads/develop
       - refs/tags/**
 
 steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
+  - name: Create Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     pull: always
-    volumes:
-      - name: shared
-        path: /shared
     depends_on: [clone]
-    settings:
-      action: custom-cluster-125
-      pipeline_id: cluster-125-gatekeeper
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: "1.25.3"
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
-    image: quay.io/sighup/e2e-testing:1.1.0_0.9.0_3.1.1_1.9.4_1.25.3_3.5.3_4.21.1
-    pull: always
     volumes:
-      - name: shared
-        path: /shared
-    depends_on: [init]
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.26.6
+      KUBECONFIG: kubeconfig-126
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-126
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-125
-      - bats -t katalog/tests/gatekeeper.sh
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
-    pull: always
-    depends_on: [e2e]
-    settings:
-      action: destroy
-      pipeline_id: cluster-125-gatekeeper
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: shared
-    temp: {}
----
-name: e2e-kubernetes-1.26-gatekeeper
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-node:
-  runner: internal
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/heads/master
-      - refs/heads/main
-      - refs/heads/develop
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.26.4
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [clone]
-    settings:
-      action: custom-cluster-126
-      pipeline_id: cluster-126-gatekeeper
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: "1.26.4"
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
+  - name: End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
     image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
     pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [init]
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-126
+    depends_on: ["Create Kind Cluster"]
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-126
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
       - bats -t katalog/tests/gatekeeper.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.26.4
-    pull: always
-    depends_on: [e2e]
-    settings:
-      action: destroy
-      pipeline_id: cluster-126-gatekeeper
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: shared
-    temp: {}
-
----
-name: e2e-kubernetes-1.27-gatekeeper
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-node:
-  runner: internal
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/heads/master
-      - refs/heads/main
-      - refs/heads/develop
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.27.1
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [clone]
-    settings:
-      action: custom-cluster-127
-      pipeline_id: cluster-127-gatekeeper
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: "1.27.1"
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.12.0_1.9.4_1.27.1_3.5.3_4.33.3
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [init]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-127
-      - bats -t katalog/tests/gatekeeper.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.27.1
-    pull: always
-    depends_on: [e2e]
-    settings:
-      action: destroy
-      pipeline_id: cluster-127-gatekeeper
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: shared
-    temp: {}
-
----
-name: e2e-kubernetes-1.25-kyverno
-kind: pipeline
-type: docker
-
-depends_on:
-  - e2e-kubernetes-1.25-gatekeeper
-  - e2e-kubernetes-1.26-gatekeeper
-  - e2e-kubernetes-1.27-gatekeeper
-
-node:
-  runner: internal
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/heads/master
-      - refs/heads/main
-      - refs/heads/develop
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [clone]
-    settings:
-      action: custom-cluster-125
-      pipeline_id: cluster-125-kyverno
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: "1.25.3"
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
-    image: quay.io/sighup/e2e-testing:1.1.0_0.9.0_3.1.1_1.9.4_1.25.3_3.5.3_4.21.1
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [init]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-125
       - bats -t katalog/tests/kyverno.sh
 
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
-    pull: always
-    depends_on: [e2e]
-    settings:
-      action: destroy
-      pipeline_id: cluster-125-kyverno
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-126
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - End-to-End Tests
     when:
       status:
         - success
         - failure
 
 volumes:
-  - name: shared
-    temp: {}
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+
 ---
-name: e2e-kubernetes-1.26-kyverno
+name: E2E Tests Kubernetes 1.27
 kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.25-gatekeeper
-  - e2e-kubernetes-1.26-gatekeeper
-  - e2e-kubernetes-1.27-gatekeeper
+  - Linting
 
-node:
-  runner: internal
+clone:
+  depth: 1
 
 platform:
   os: linux
@@ -488,101 +171,75 @@ platform:
 trigger:
   ref:
     include:
-      - refs/heads/master
       - refs/heads/main
-      - refs/heads/develop
       - refs/tags/**
 
 steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.26.4
+  - name: Create Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     pull: always
-    volumes:
-      - name: shared
-        path: /shared
     depends_on: [clone]
-    settings:
-      action: custom-cluster-126
-      pipeline_id: cluster-126-kyverno
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: "1.26.4"
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.27.3
+      KUBECONFIG: kubeconfig-127
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-127
+    commands:
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
-  - name: e2e
+  - name: End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
     image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
     pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [init]
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-127
+    depends_on: ["Create Kind Cluster"]
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-126
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t katalog/tests/gatekeeper.sh
       - bats -t katalog/tests/kyverno.sh
 
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.26.4
-    pull: always
-    depends_on: [e2e]
-    settings:
-      action: destroy
-      pipeline_id: cluster-126-kyverno
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-127
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - End-to-End Tests
     when:
       status:
         - success
         - failure
 
 volumes:
-  - name: shared
-    temp: {}
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
 
 ---
-name: e2e-kubernetes-1.27-kyverno
+name: E2E Tests Kubernetes 1.28
 kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.25-gatekeeper
-  - e2e-kubernetes-1.26-gatekeeper
-  - e2e-kubernetes-1.27-gatekeeper
+  - Linting
 
-node:
-  runner: internal
+clone:
+  depth: 1
 
 platform:
   os: linux
@@ -591,101 +248,155 @@ platform:
 trigger:
   ref:
     include:
-      - refs/heads/master
       - refs/heads/main
-      - refs/heads/develop
       - refs/tags/**
 
 steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.27.1
+  - name: Create Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     pull: always
-    volumes:
-      - name: shared
-        path: /shared
     depends_on: [clone]
-    settings:
-      action: custom-cluster-127
-      pipeline_id: cluster-127-kyverno
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: "1.27.1"
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.12.0_1.9.4_1.27.1_3.5.3_4.33.3
-    pull: always
     volumes:
-      - name: shared
-        path: /shared
-    depends_on: [init]
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.28.0
+      KUBECONFIG: kubeconfig-128
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-128
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-127
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-128
+    depends_on: ["Create Kind Cluster"]
+    commands:
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t katalog/tests/gatekeeper.sh
       - bats -t katalog/tests/kyverno.sh
 
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.27.1
-    pull: always
-    depends_on: [e2e]
-    settings:
-      action: destroy
-      pipeline_id: cluster-127-kyverno
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-128
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - End-to-End Tests
     when:
       status:
         - success
         - failure
 
 volumes:
-  - name: shared
-    temp: {}
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+
+---
+name: E2E Tests Kubernetes 1.29
+kind: pipeline
+type: docker
+
+depends_on:
+  - Linting
+
+clone:
+  depth: 1
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: Create Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    depends_on: [clone]
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.29.0
+      KUBECONFIG: kubeconfig-129
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-129
+    commands:
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-129
+    depends_on: ["Create Kind Cluster"]
+    commands:
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t katalog/tests/gatekeeper.sh
+      - bats -t katalog/tests/kyverno.sh
+
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-129
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - End-to-End Tests
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
 
 ---
 name: release
 kind: pipeline
 type: docker
 
+clone:
+  depth: 1
+
 depends_on:
-  - e2e-kubernetes-1.25-gatekeeper
-  - e2e-kubernetes-1.26-gatekeeper
-  - e2e-kubernetes-1.27-gatekeeper
-  - e2e-kubernetes-1.25-kyverno
-  - e2e-kubernetes-1.26-kyverno
-  - e2e-kubernetes-1.27-kyverno
+  - E2E Tests Kubernetes 1.26
+  - E2E Tests Kubernetes 1.27
+  - E2E Tests Kubernetes 1.28
+  - E2E Tests Kubernetes 1.29
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ steps:
     pull: always
     commands:
       - go install github.com/google/addlicense@v1.1.1
-      - addlicense -c "SIGHUP s.r.l" -v -l bsd --check .
+      - addlicense -c "SIGHUP s.r.l" -v -l bsd -y "2017-present" --check .
 
 ---
 name: Linting
@@ -77,7 +77,7 @@ steps:
       KUBERNETES_MANIFESTS: kyverno.yml
 
 ---
-name: E2E Tests Kubernetes 1.26
+name: E2E Tests Kubernetes v1.26.6
 kind: pipeline
 type: docker
 
@@ -98,18 +98,19 @@ trigger:
       - refs/tags/**
 
 steps:
-  - name: Create Kind Cluster
+  - name: Create Kind Cluster for Gatekeeper
     image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     pull: always
-    depends_on: [clone]
+    depends_on:
+      - clone
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
       KIND_CONFIG: ./katalog/tests/kind/config.yml
       CLUSTER_VERSION: v1.26.6
-      KUBECONFIG: kubeconfig-126
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-126
+      KUBECONFIG: kubeconfig-gatekeeper-v1.26.6
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-gatekeeper-v1.26.6
     commands:
       # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
       # does not work when disabling the default CNI. It will always go in timeout.
@@ -117,44 +118,95 @@ steps:
       # save the kubeconfig so we can use it from other steps.
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
-  - name: End-to-End Tests
+  - name: Gatekeeper End-to-End Tests
     # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
     image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
     pull: always
     network_mode: host
     environment:
-      KUBECONFIG: kubeconfig-126
-    depends_on: ["Create Kind Cluster"]
+      KUBECONFIG: kubeconfig-gatekeeper-v1.26.6
+    depends_on:
+      - Create Kind Cluster for Gatekeeper
     commands:
       # wait for Kind cluster to be ready
       - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
       - bats -t katalog/tests/gatekeeper.sh
-      - bats -t katalog/tests/kyverno.sh
 
-  - name: Destroy Kind Cluster
+  - name: Destroy Kind Cluster for Gatekeeper
     image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-126
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-gatekeeper-v1.26.6
     commands:
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
-      - End-to-End Tests
+      - Gatekeeper End-to-End Tests
     when:
       status:
         - success
         - failure
 
+  # kyverno cluster and e2e tests
+  - name: Create Kind Cluster for Kyverno
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    depends_on:
+      - clone
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.26.6
+      KUBECONFIG: kubeconfig-kyverno-v1.26.6
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-kyverno-v1.26.6
+    commands:
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: Kyverno End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-kyverno-v1.26.6
+    depends_on:
+      - Create Kind Cluster for Kyverno
+    commands:
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t katalog/tests/kyverno.sh
+
+  - name: Destroy Kind Cluster for Kyverno
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-kyverno-v1.26.6
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - Kyverno End-to-End Tests
+    when:
+      status:
+        - success
+        - failure
 volumes:
   - name: dockersock
     host:
       path: /var/run/docker.sock
 
 ---
-name: E2E Tests Kubernetes 1.27
+name: E2E Tests Kubernetes v1.27.3
 kind: pipeline
 type: docker
 
@@ -175,18 +227,19 @@ trigger:
       - refs/tags/**
 
 steps:
-  - name: Create Kind Cluster
+  - name: Create Kind Cluster for Gatekeeper
     image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     pull: always
-    depends_on: [clone]
+    depends_on:
+      - clone
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
       KIND_CONFIG: ./katalog/tests/kind/config.yml
       CLUSTER_VERSION: v1.27.3
-      KUBECONFIG: kubeconfig-127
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-127
+      KUBECONFIG: kubeconfig-gatekeeper-v1.27.3
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-gatekeeper-v1.27.3
     commands:
       # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
       # does not work when disabling the default CNI. It will always go in timeout.
@@ -194,44 +247,95 @@ steps:
       # save the kubeconfig so we can use it from other steps.
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
-  - name: End-to-End Tests
+  - name: Gatekeeper End-to-End Tests
     # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
     image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
     pull: always
     network_mode: host
     environment:
-      KUBECONFIG: kubeconfig-127
-    depends_on: ["Create Kind Cluster"]
+      KUBECONFIG: kubeconfig-gatekeeper-v1.27.3
+    depends_on:
+      - Create Kind Cluster for Gatekeeper
     commands:
       # wait for Kind cluster to be ready
       - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
       - bats -t katalog/tests/gatekeeper.sh
-      - bats -t katalog/tests/kyverno.sh
 
-  - name: Destroy Kind Cluster
+  - name: Destroy Kind Cluster for Gatekeeper
     image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-127
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-gatekeeper-v1.27.3
     commands:
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
-      - End-to-End Tests
+      - Gatekeeper End-to-End Tests
     when:
       status:
         - success
         - failure
 
+  # kyverno cluster and e2e tests
+  - name: Create Kind Cluster for Kyverno
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    depends_on:
+      - clone
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.27.3
+      KUBECONFIG: kubeconfig-kyverno-v1.27.3
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-kyverno-v1.27.3
+    commands:
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: Kyverno End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-kyverno-v1.27.3
+    depends_on:
+      - Create Kind Cluster for Kyverno
+    commands:
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t katalog/tests/kyverno.sh
+
+  - name: Destroy Kind Cluster for Kyverno
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-kyverno-v1.27.3
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - Kyverno End-to-End Tests
+    when:
+      status:
+        - success
+        - failure
 volumes:
   - name: dockersock
     host:
       path: /var/run/docker.sock
 
 ---
-name: E2E Tests Kubernetes 1.28
+name: E2E Tests Kubernetes v1.28.0
 kind: pipeline
 type: docker
 
@@ -252,18 +356,19 @@ trigger:
       - refs/tags/**
 
 steps:
-  - name: Create Kind Cluster
+  - name: Create Kind Cluster for Gatekeeper
     image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     pull: always
-    depends_on: [clone]
+    depends_on:
+      - clone
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
       KIND_CONFIG: ./katalog/tests/kind/config.yml
       CLUSTER_VERSION: v1.28.0
-      KUBECONFIG: kubeconfig-128
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-128
+      KUBECONFIG: kubeconfig-gatekeeper-v1.28.0
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-gatekeeper-v1.28.0
     commands:
       # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
       # does not work when disabling the default CNI. It will always go in timeout.
@@ -271,44 +376,95 @@ steps:
       # save the kubeconfig so we can use it from other steps.
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
-  - name: End-to-End Tests
+  - name: Gatekeeper End-to-End Tests
     # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
     image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
     pull: always
     network_mode: host
     environment:
-      KUBECONFIG: kubeconfig-128
-    depends_on: ["Create Kind Cluster"]
+      KUBECONFIG: kubeconfig-gatekeeper-v1.28.0
+    depends_on:
+      - Create Kind Cluster for Gatekeeper
     commands:
       # wait for Kind cluster to be ready
       - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
       - bats -t katalog/tests/gatekeeper.sh
-      - bats -t katalog/tests/kyverno.sh
 
-  - name: Destroy Kind Cluster
+  - name: Destroy Kind Cluster for Gatekeeper
     image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-128
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-gatekeeper-v1.28.0
     commands:
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
-      - End-to-End Tests
+      - Gatekeeper End-to-End Tests
     when:
       status:
         - success
         - failure
 
+  # kyverno cluster and e2e tests
+  - name: Create Kind Cluster for Kyverno
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    depends_on:
+      - clone
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.28.0
+      KUBECONFIG: kubeconfig-kyverno-v1.28.0
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-kyverno-v1.28.0
+    commands:
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: Kyverno End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-kyverno-v1.28.0
+    depends_on:
+      - Create Kind Cluster for Kyverno
+    commands:
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t katalog/tests/kyverno.sh
+
+  - name: Destroy Kind Cluster for Kyverno
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-kyverno-v1.28.0
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - Kyverno End-to-End Tests
+    when:
+      status:
+        - success
+        - failure
 volumes:
   - name: dockersock
     host:
       path: /var/run/docker.sock
 
 ---
-name: E2E Tests Kubernetes 1.29
+name: E2E Tests Kubernetes v1.29.0
 kind: pipeline
 type: docker
 
@@ -329,18 +485,19 @@ trigger:
       - refs/tags/**
 
 steps:
-  - name: Create Kind Cluster
+  - name: Create Kind Cluster for Gatekeeper
     image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     pull: always
-    depends_on: [clone]
+    depends_on:
+      - clone
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
       KIND_CONFIG: ./katalog/tests/kind/config.yml
       CLUSTER_VERSION: v1.29.0
-      KUBECONFIG: kubeconfig-129
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-129
+      KUBECONFIG: kubeconfig-gatekeeper-v1.29.0
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-gatekeeper-v1.29.0
     commands:
       # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
       # does not work when disabling the default CNI. It will always go in timeout.
@@ -348,43 +505,94 @@ steps:
       # save the kubeconfig so we can use it from other steps.
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
-  - name: End-to-End Tests
+  - name: Gatekeeper End-to-End Tests
     # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
     image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
     pull: always
     network_mode: host
     environment:
-      KUBECONFIG: kubeconfig-129
-    depends_on: ["Create Kind Cluster"]
+      KUBECONFIG: kubeconfig-gatekeeper-v1.29.0
+    depends_on:
+      - Create Kind Cluster for Gatekeeper
     commands:
       # wait for Kind cluster to be ready
       - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
       - bats -t katalog/tests/gatekeeper.sh
-      - bats -t katalog/tests/kyverno.sh
 
-  - name: Destroy Kind Cluster
+  - name: Destroy Kind Cluster for Gatekeeper
     image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-129
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-gatekeeper-v1.29.0
     commands:
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
-      - End-to-End Tests
+      - Gatekeeper End-to-End Tests
     when:
       status:
         - success
         - failure
 
+  # kyverno cluster and e2e tests
+  - name: Create Kind Cluster for Kyverno
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    depends_on:
+      - clone
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.29.0
+      KUBECONFIG: kubeconfig-kyverno-v1.29.0
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-kyverno-v1.29.0
+    commands:
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: Kyverno End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-kyverno-v1.29.0
+    depends_on:
+      - Create Kind Cluster for Kyverno
+    commands:
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t katalog/tests/kyverno.sh
+
+  - name: Destroy Kind Cluster for Kyverno
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-kyverno-v1.29.0
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - Kyverno End-to-End Tests
+    when:
+      status:
+        - success
+        - failure
 volumes:
   - name: dockersock
     host:
       path: /var/run/docker.sock
-
 ---
+
 name: release
 kind: pipeline
 type: docker
@@ -393,10 +601,10 @@ clone:
   depth: 1
 
 depends_on:
-  - E2E Tests Kubernetes 1.26
-  - E2E Tests Kubernetes 1.27
-  - E2E Tests Kubernetes 1.28
-  - E2E Tests Kubernetes 1.29
+  - E2E Tests Kubernetes v1.26.6
+  - E2E Tests Kubernetes v1.27.3
+  - E2E Tests Kubernetes v1.28.0
+  - E2E Tests Kubernetes v1.29.0
 
 platform:
   os: linux

--- a/katalog/tests/kind/config.yml
+++ b/katalog/tests/kind/config.yml
@@ -6,27 +6,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerAddress: "0.0.0.0"
-# One control plane node and three "workers".
-#
-# While these will not add more real compute capacity and
-# have limited isolation, this can be useful for testing
-# rolling updates etc.
-#
-# The API-server and other control plane components will be
-# on the control-plane node.
-#
-# You probably don't need this unless you are testing Kubernetes itself.
 nodes:
-- role: control-plane
-- role: worker
-- role: worker
-- role: worker
-
-containerdConfigPatches:
-- |-
-    [debug]
-      level = "debug"
-    [plugins."io.containerd.grpc.v1.cri".registry]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://mirror.gcr.io", "https://registry-1.docker.io"]
+  - role: control-plane
+  - role: worker


### PR DESCRIPTION

We've implemented KIND (Kubernetes in Docker) for running E2E tests, ensuring compatibility and functionality across Kubernetes versions:
 - 1.26.6
 - 1.27.3
 - 1.28.0
 - 1.29.0

Additionally, we've updated the Pluto target version to k8s=v1.29.0 to check for deprecated APIs against this Kubernetes version.