### PR TITLE
feat: update OPA Gatekeeper to v3.17.1

### DIFF
--- a/katalog/gatekeeper/README.md
+++ b/katalog/gatekeeper/README.md
@@ -24,7 +24,7 @@ This module can easily be added to your existing Fury setup adding to your `Fury
 bases:
   (...)
   - name: opa/gatekeeper
-    version: "1.10.0"
+    version: "1.12.0"
 ```
 
 Once you'll do this, you can then proceed to integrate Gatekeeper into your Kustomize project.
@@ -114,7 +114,7 @@ are removed by Gatekeeper. Otherwise, the finalizers will need to be removed man
 
 ### Before Uninstall, Clean Up Old Constraints
 
-Currently, the uninstall mechanism only removes the Gatekeeper system,
+Currently, the uninstallation mechanism only removes the Gatekeeper system,
 it does not remove any `ConstraintTemplate`, `Constraint`, and `Config` resources that have been created by the user,
 nor does it remove their accompanying `CRDs`.
 

--- a/katalog/gatekeeper/core/MAINTENANCE.md
+++ b/katalog/gatekeeper/core/MAINTENANCE.md
@@ -4,8 +4,8 @@
 
 ```bash
 # Assuming ${PWD} == the root of the project
-export GATEKEEPER_VERSION=v3.15.1
-curl https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-${GATEKEEPER_VERSION}/deploy/gatekeeper.yaml -o upstream.yaml
+export GATEKEEPER_VERSION=v3.17.1
+curl -l https://raw.githubusercontent.com/open-policy-agent/gatekeeper/refs/tags/${GATEKEEPER_VERSION}/deploy/gatekeeper.yaml -o upstream.yaml
 cat katalog/gatekeeper/core/ns.yml \
     katalog/gatekeeper/core/crd.yml \
     katalog/gatekeeper/core/sa.yml \
@@ -30,11 +30,12 @@ diff the generated `local.yaml` with the `upstream.yaml` file and port the neede
 
 Please notice that it is expected that some objects don't have the namespace set as in upstream, this is because the namespace is set with Kustomize.
 
-2. Sync the new image to our registry by updating the [OPA images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/opa/images.yml).
+1. Sync the new image to our registry by updating the [OPA images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/opa/images.yml).
 
-3. Update the `kustomization.yaml` file with the new version in the image tag.
+2. Update the `kustomization.yaml` file with the new version in the image tag.
 
 ## Customizations
 
 - We enable monitoring of metrics by default, so we added some parameters to scrape them.
 - We delete the namespace from resources definitions, the namespace is set by Kustomize.
+- We create an additional service for the audit endpoint.

--- a/katalog/gatekeeper/core/crd.yml
+++ b/katalog/gatekeeper/core/crd.yml
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assign.mutations.gatekeeper.sh
@@ -27,10 +27,19 @@ spec:
           description: Assign is the Schema for the assign API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               properties:
@@ -42,9 +51,14 @@ spec:
               description: AssignSpec defines the desired state of Assign.
               properties:
                 applyTo:
-                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  description: |-
+                    ApplyTo lists the specific groups, versions and kinds a mutation will be applied to.
+                    This is necessary because every mutation implies part of an object schema and object
+                    schemas are associated with specific GVKs.
                   items:
-                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    description: |-
+                      ApplyTo determines what GVKs items the mutation should apply to.
+                      Globs are not allowed.
                     properties:
                       groups:
                         items:
@@ -64,21 +78,40 @@ spec:
                   description: "Location describes the path to be mutated, for example: `spec.containers[name: main]`."
                   type: string
                 match:
-                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
+                  description: |-
+                    Match allows the user to limit which resources get mutated.
+                    Individual match criteria are AND-ed together. An undefined
+                    match criteria matches everything.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -89,81 +122,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -181,17 +267,23 @@ spec:
                           properties:
                             dataSource:
                               default: ValueAtLocation
-                              description: DataSource specifies where to extract the data that will be sent to the external data provider as parameters.
+                              description: |-
+                                DataSource specifies where to extract the data that will be sent
+                                to the external data provider as parameters.
                               enum:
                                 - ValueAtLocation
                                 - Username
                               type: string
                             default:
-                              description: Default specifies the default value to use when the external data provider returns an error and the failure policy is set to "UseDefault".
+                              description: |-
+                                Default specifies the default value to use when the external data
+                                provider returns an error and the failure policy is set to "UseDefault".
                               type: string
                             failurePolicy:
                               default: Fail
-                              description: FailurePolicy specifies the policy to apply when the external data provider returns an error.
+                              description: |-
+                                FailurePolicy specifies the policy to apply when the external data
+                                provider returns an error.
                               enum:
                                 - UseDefault
                                 - Ignore
@@ -214,7 +306,18 @@ spec:
                       type: object
                     pathTests:
                       items:
-                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        description: |-
+                          PathTest allows the user to customize how the mutation works if parent
+                          paths are missing. It traverses the list in order. All sub paths are
+                          tested against the provided condition, if the test fails, the mutation is
+                          not applied. All `subPath` entries must be a prefix of `location`. Any
+                          glob characters will take on the same value as was used to
+                          expand the matching glob in `location`.
+
+
+                          Available Tests:
+                          * MustExist    - the path must exist or do not mutate
+                          * MustNotExist - the path must not exist or do not mutate.
                         properties:
                           condition:
                             description: Condition describes whether the path either MustExist or MustNotExist in the original object
@@ -244,7 +347,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -253,7 +358,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -276,10 +384,19 @@ spec:
           description: Assign is the Schema for the assign API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -287,9 +404,14 @@ spec:
               description: AssignSpec defines the desired state of Assign.
               properties:
                 applyTo:
-                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  description: |-
+                    ApplyTo lists the specific groups, versions and kinds a mutation will be applied to.
+                    This is necessary because every mutation implies part of an object schema and object
+                    schemas are associated with specific GVKs.
                   items:
-                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    description: |-
+                      ApplyTo determines what GVKs items the mutation should apply to.
+                      Globs are not allowed.
                     properties:
                       groups:
                         items:
@@ -309,21 +431,40 @@ spec:
                   description: "Location describes the path to be mutated, for example: `spec.containers[name: main]`."
                   type: string
                 match:
-                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
+                  description: |-
+                    Match allows the user to limit which resources get mutated.
+                    Individual match criteria are AND-ed together. An undefined
+                    match criteria matches everything.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -334,81 +475,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -426,17 +620,23 @@ spec:
                           properties:
                             dataSource:
                               default: ValueAtLocation
-                              description: DataSource specifies where to extract the data that will be sent to the external data provider as parameters.
+                              description: |-
+                                DataSource specifies where to extract the data that will be sent
+                                to the external data provider as parameters.
                               enum:
                                 - ValueAtLocation
                                 - Username
                               type: string
                             default:
-                              description: Default specifies the default value to use when the external data provider returns an error and the failure policy is set to "UseDefault".
+                              description: |-
+                                Default specifies the default value to use when the external data
+                                provider returns an error and the failure policy is set to "UseDefault".
                               type: string
                             failurePolicy:
                               default: Fail
-                              description: FailurePolicy specifies the policy to apply when the external data provider returns an error.
+                              description: |-
+                                FailurePolicy specifies the policy to apply when the external data
+                                provider returns an error.
                               enum:
                                 - UseDefault
                                 - Ignore
@@ -459,7 +659,18 @@ spec:
                       type: object
                     pathTests:
                       items:
-                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        description: |-
+                          PathTest allows the user to customize how the mutation works if parent
+                          paths are missing. It traverses the list in order. All sub paths are
+                          tested against the provided condition, if the test fails, the mutation is
+                          not applied. All `subPath` entries must be a prefix of `location`. Any
+                          glob characters will take on the same value as was used to
+                          expand the matching glob in `location`.
+
+
+                          Available Tests:
+                          * MustExist    - the path must exist or do not mutate
+                          * MustNotExist - the path must not exist or do not mutate.
                         properties:
                           condition:
                             description: Condition describes whether the path either MustExist or MustNotExist in the original object
@@ -489,7 +700,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -498,7 +711,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -521,10 +737,19 @@ spec:
           description: Assign is the Schema for the assign API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -532,9 +757,14 @@ spec:
               description: AssignSpec defines the desired state of Assign.
               properties:
                 applyTo:
-                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  description: |-
+                    ApplyTo lists the specific groups, versions and kinds a mutation will be applied to.
+                    This is necessary because every mutation implies part of an object schema and object
+                    schemas are associated with specific GVKs.
                   items:
-                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    description: |-
+                      ApplyTo determines what GVKs items the mutation should apply to.
+                      Globs are not allowed.
                     properties:
                       groups:
                         items:
@@ -554,21 +784,40 @@ spec:
                   description: "Location describes the path to be mutated, for example: `spec.containers[name: main]`."
                   type: string
                 match:
-                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
+                  description: |-
+                    Match allows the user to limit which resources get mutated.
+                    Individual match criteria are AND-ed together. An undefined
+                    match criteria matches everything.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -579,81 +828,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -671,17 +973,23 @@ spec:
                           properties:
                             dataSource:
                               default: ValueAtLocation
-                              description: DataSource specifies where to extract the data that will be sent to the external data provider as parameters.
+                              description: |-
+                                DataSource specifies where to extract the data that will be sent
+                                to the external data provider as parameters.
                               enum:
                                 - ValueAtLocation
                                 - Username
                               type: string
                             default:
-                              description: Default specifies the default value to use when the external data provider returns an error and the failure policy is set to "UseDefault".
+                              description: |-
+                                Default specifies the default value to use when the external data
+                                provider returns an error and the failure policy is set to "UseDefault".
                               type: string
                             failurePolicy:
                               default: Fail
-                              description: FailurePolicy specifies the policy to apply when the external data provider returns an error.
+                              description: |-
+                                FailurePolicy specifies the policy to apply when the external data
+                                provider returns an error.
                               enum:
                                 - UseDefault
                                 - Ignore
@@ -704,7 +1012,18 @@ spec:
                       type: object
                     pathTests:
                       items:
-                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        description: |-
+                          PathTest allows the user to customize how the mutation works if parent
+                          paths are missing. It traverses the list in order. All sub paths are
+                          tested against the provided condition, if the test fails, the mutation is
+                          not applied. All `subPath` entries must be a prefix of `location`. Any
+                          glob characters will take on the same value as was used to
+                          expand the matching glob in `location`.
+
+
+                          Available Tests:
+                          * MustExist    - the path must exist or do not mutate
+                          * MustNotExist - the path must not exist or do not mutate.
                         properties:
                           condition:
                             description: Condition describes whether the path either MustExist or MustNotExist in the original object
@@ -734,7 +1053,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -743,7 +1064,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -765,7 +1089,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignimage.mutations.gatekeeper.sh
@@ -785,10 +1109,19 @@ spec:
           description: AssignImage is the Schema for the assignimage API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               properties:
@@ -800,9 +1133,14 @@ spec:
               description: AssignImageSpec defines the desired state of AssignImage.
               properties:
                 applyTo:
-                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  description: |-
+                    ApplyTo lists the specific groups, versions and kinds a mutation will be applied to.
+                    This is necessary because every mutation implies part of an object schema and object
+                    schemas are associated with specific GVKs.
                   items:
-                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    description: |-
+                      ApplyTo determines what GVKs items the mutation should apply to.
+                      Globs are not allowed.
                     properties:
                       groups:
                         items:
@@ -822,21 +1160,40 @@ spec:
                   description: "Location describes the path to be mutated, for example: `spec.containers[name: main].image`."
                   type: string
                 match:
-                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
+                  description: |-
+                    Match allows the user to limit which resources get mutated.
+                    Individual match criteria are AND-ed together. An undefined
+                    match criteria matches everything.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -847,81 +1204,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -932,17 +1342,32 @@ spec:
                   description: Parameters define the behavior of the mutator.
                   properties:
                     assignDomain:
-                      description: AssignDomain sets the domain component on an image string. The trailing slash should not be included.
+                      description: |-
+                        AssignDomain sets the domain component on an image string. The trailing
+                        slash should not be included.
                       type: string
                     assignPath:
                       description: AssignPath sets the domain component on an image string.
                       type: string
                     assignTag:
-                      description: AssignImage sets the image component on an image string. It must start with a `:` or `@`.
+                      description: |-
+                        AssignImage sets the image component on an image string. It must start
+                        with a `:` or `@`.
                       type: string
                     pathTests:
                       items:
-                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        description: |-
+                          PathTest allows the user to customize how the mutation works if parent
+                          paths are missing. It traverses the list in order. All sub paths are
+                          tested against the provided condition, if the test fails, the mutation is
+                          not applied. All `subPath` entries must be a prefix of `location`. Any
+                          glob characters will take on the same value as was used to
+                          expand the matching glob in `location`.
+
+
+                          Available Tests:
+                          * MustExist    - the path must exist or do not mutate
+                          * MustNotExist - the path must not exist or do not mutate.
                         properties:
                           condition:
                             description: Condition describes whether the path either MustExist or MustNotExist in the original object
@@ -972,7 +1397,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -981,7 +1408,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -1003,7 +1433,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignmetadata.mutations.gatekeeper.sh
@@ -1023,10 +1453,19 @@ spec:
           description: AssignMetadata is the Schema for the assignmetadata API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               properties:
@@ -1043,18 +1482,34 @@ spec:
                   description: Match selects which objects are in scope.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -1065,81 +1520,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -1156,17 +1664,23 @@ spec:
                           properties:
                             dataSource:
                               default: ValueAtLocation
-                              description: DataSource specifies where to extract the data that will be sent to the external data provider as parameters.
+                              description: |-
+                                DataSource specifies where to extract the data that will be sent
+                                to the external data provider as parameters.
                               enum:
                                 - ValueAtLocation
                                 - Username
                               type: string
                             default:
-                              description: Default specifies the default value to use when the external data provider returns an error and the failure policy is set to "UseDefault".
+                              description: |-
+                                Default specifies the default value to use when the external data
+                                provider returns an error and the failure policy is set to "UseDefault".
                               type: string
                             failurePolicy:
                               default: Fail
-                              description: FailurePolicy specifies the policy to apply when the external data provider returns an error.
+                              description: |-
+                                FailurePolicy specifies the policy to apply when the external data
+                                provider returns an error.
                               enum:
                                 - UseDefault
                                 - Ignore
@@ -1193,7 +1707,9 @@ spec:
               description: AssignMetadataStatus defines the observed state of AssignMetadata.
               properties:
                 byPod:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+                  description: |-
+                    INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                    Important: Run "make" to regenerate code after modifying this file
                   items:
                     description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
                     properties:
@@ -1206,7 +1722,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -1215,7 +1733,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -1238,10 +1759,19 @@ spec:
           description: AssignMetadata is the Schema for the assignmetadata API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -1254,18 +1784,34 @@ spec:
                   description: Match selects which objects are in scope.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -1276,81 +1822,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -1367,17 +1966,23 @@ spec:
                           properties:
                             dataSource:
                               default: ValueAtLocation
-                              description: DataSource specifies where to extract the data that will be sent to the external data provider as parameters.
+                              description: |-
+                                DataSource specifies where to extract the data that will be sent
+                                to the external data provider as parameters.
                               enum:
                                 - ValueAtLocation
                                 - Username
                               type: string
                             default:
-                              description: Default specifies the default value to use when the external data provider returns an error and the failure policy is set to "UseDefault".
+                              description: |-
+                                Default specifies the default value to use when the external data
+                                provider returns an error and the failure policy is set to "UseDefault".
                               type: string
                             failurePolicy:
                               default: Fail
-                              description: FailurePolicy specifies the policy to apply when the external data provider returns an error.
+                              description: |-
+                                FailurePolicy specifies the policy to apply when the external data
+                                provider returns an error.
                               enum:
                                 - UseDefault
                                 - Ignore
@@ -1404,7 +2009,9 @@ spec:
               description: AssignMetadataStatus defines the observed state of AssignMetadata.
               properties:
                 byPod:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+                  description: |-
+                    INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                    Important: Run "make" to regenerate code after modifying this file
                   items:
                     description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
                     properties:
@@ -1417,7 +2024,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -1426,7 +2035,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -1449,10 +2061,19 @@ spec:
           description: AssignMetadata is the Schema for the assignmetadata API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -1465,18 +2086,34 @@ spec:
                   description: Match selects which objects are in scope.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -1487,81 +2124,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -1578,17 +2268,23 @@ spec:
                           properties:
                             dataSource:
                               default: ValueAtLocation
-                              description: DataSource specifies where to extract the data that will be sent to the external data provider as parameters.
+                              description: |-
+                                DataSource specifies where to extract the data that will be sent
+                                to the external data provider as parameters.
                               enum:
                                 - ValueAtLocation
                                 - Username
                               type: string
                             default:
-                              description: Default specifies the default value to use when the external data provider returns an error and the failure policy is set to "UseDefault".
+                              description: |-
+                                Default specifies the default value to use when the external data
+                                provider returns an error and the failure policy is set to "UseDefault".
                               type: string
                             failurePolicy:
                               default: Fail
-                              description: FailurePolicy specifies the policy to apply when the external data provider returns an error.
+                              description: |-
+                                FailurePolicy specifies the policy to apply when the external data
+                                provider returns an error.
                               enum:
                                 - UseDefault
                                 - Ignore
@@ -1615,7 +2311,9 @@ spec:
               description: AssignMetadataStatus defines the observed state of AssignMetadata.
               properties:
                 byPod:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+                  description: |-
+                    INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                    Important: Run "make" to regenerate code after modifying this file
                   items:
                     description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
                     properties:
@@ -1628,7 +2326,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -1637,7 +2337,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -1659,7 +2362,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: configs.config.gatekeeper.sh
@@ -1679,10 +2382,19 @@ spec:
           description: Config is the Schema for the configs API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -1695,8 +2407,11 @@ spec:
                     properties:
                       excludedNamespaces:
                         items:
-                          description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                          pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                          description: |-
+                            A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                            "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                            match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                          pattern: ^\*?[-:a-z0-9]*\*?$
                           type: string
                         type: array
                       processes:
@@ -1765,7 +2480,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constraintpodstatuses.status.gatekeeper.sh
@@ -1785,10 +2500,19 @@ spec:
           description: ConstraintPodStatus is the Schema for the constraintpodstatuses API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -1796,13 +2520,16 @@ spec:
               description: ConstraintPodStatusStatus defines the observed state of ConstraintPodStatus.
               properties:
                 constraintUID:
-                  description: Storing the constraint UID allows us to detect drift, such as when a constraint has been recreated after its CRD was deleted out from under it, interrupting the watch
+                  description: |-
+                    Storing the constraint UID allows us to detect drift, such as
+                    when a constraint has been recreated after its CRD was deleted
+                    out from under it, interrupting the watch
                   type: string
                 enforced:
                   type: boolean
                 errors:
                   items:
-                    description: Error represents a single error caught while adding a constraint to OPA.
+                    description: Error represents a single error caught while adding a constraint to engine.
                     properties:
                       code:
                         type: string
@@ -1833,7 +2560,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constrainttemplatepodstatuses.status.gatekeeper.sh
@@ -1853,10 +2580,19 @@ spec:
           description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -1889,7 +2625,10 @@ spec:
                     type: string
                   type: array
                 templateUID:
-                  description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                  description: |-
+                    UID is a type that holds unique ID values, including UUIDs.  Because we
+                    don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                    intent and helps make sure that UIDs and names do not get conflated.
                   type: string
               type: object
           type: object
@@ -1900,7 +2639,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constrainttemplates.templates.gatekeeper.sh
@@ -1920,10 +2659,19 @@ spec:
           description: ConstraintTemplate is the Schema for the constrainttemplates API
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -1960,7 +2708,9 @@ spec:
                   items:
                     properties:
                       code:
-                        description: The source code options for the constraint template. "Rego" can only be specified in one place (either here or in the "rego" field)
+                        description: |-
+                          The source code options for the constraint template. "Rego" can only
+                          be specified in one place (either here or in the "rego" field)
                         items:
                           properties:
                             engine:
@@ -1993,7 +2743,9 @@ spec:
               properties:
                 byPod:
                   items:
-                    description: ByPodStatus defines the observed state of ConstraintTemplate as seen by an individual controller
+                    description: |-
+                      ByPodStatus defines the observed state of ConstraintTemplate as seen by
+                      an individual controller
                     properties:
                       errors:
                         items:
@@ -2033,10 +2785,19 @@ spec:
           description: ConstraintTemplate is the Schema for the constrainttemplates API
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -2073,7 +2834,9 @@ spec:
                   items:
                     properties:
                       code:
-                        description: The source code options for the constraint template. "Rego" can only be specified in one place (either here or in the "rego" field)
+                        description: |-
+                          The source code options for the constraint template. "Rego" can only
+                          be specified in one place (either here or in the "rego" field)
                         items:
                           properties:
                             engine:
@@ -2106,7 +2869,9 @@ spec:
               properties:
                 byPod:
                   items:
-                    description: ByPodStatus defines the observed state of ConstraintTemplate as seen by an individual controller
+                    description: |-
+                      ByPodStatus defines the observed state of ConstraintTemplate as seen by
+                      an individual controller
                     properties:
                       errors:
                         items:
@@ -2146,10 +2911,19 @@ spec:
           description: ConstraintTemplate is the Schema for the constrainttemplates API
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -2186,7 +2960,9 @@ spec:
                   items:
                     properties:
                       code:
-                        description: The source code options for the constraint template. "Rego" can only be specified in one place (either here or in the "rego" field)
+                        description: |-
+                          The source code options for the constraint template. "Rego" can only
+                          be specified in one place (either here or in the "rego" field)
                         items:
                           properties:
                             engine:
@@ -2219,7 +2995,9 @@ spec:
               properties:
                 byPod:
                   items:
-                    description: ByPodStatus defines the observed state of ConstraintTemplate as seen by an individual controller
+                    description: |-
+                      ByPodStatus defines the observed state of ConstraintTemplate as seen by
+                      an individual controller
                     properties:
                       errors:
                         items:
@@ -2258,7 +3036,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplate.expansion.gatekeeper.sh
@@ -2278,10 +3056,19 @@ spec:
           description: ExpansionTemplate is the Schema for the ExpansionTemplate API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               properties:
@@ -2293,9 +3080,13 @@ spec:
               description: ExpansionTemplateSpec defines the desired state of ExpansionTemplate.
               properties:
                 applyTo:
-                  description: ApplyTo lists the specific groups, versions and kinds of generator resources which will be expanded.
+                  description: |-
+                    ApplyTo lists the specific groups, versions and kinds of generator resources
+                    which will be expanded.
                   items:
-                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    description: |-
+                      ApplyTo determines what GVKs items the mutation should apply to.
+                      Globs are not allowed.
                     properties:
                       groups:
                         items:
@@ -2312,10 +3103,15 @@ spec:
                     type: object
                   type: array
                 enforcementAction:
-                  description: EnforcementAction specifies the enforcement action to be used for resources matching the ExpansionTemplate. Specifying an empty value will use the enforcement action specified by the Constraint in violation.
+                  description: |-
+                    EnforcementAction specifies the enforcement action to be used for resources
+                    matching the ExpansionTemplate. Specifying an empty value will use the
+                    enforcement action specified by the Constraint in violation.
                   type: string
                 generatedGVK:
-                  description: GeneratedGVK specifies the GVK of the resources which the generator resource creates.
+                  description: |-
+                    GeneratedGVK specifies the GVK of the resources which the generator
+                    resource creates.
                   properties:
                     group:
                       type: string
@@ -2325,7 +3121,10 @@ spec:
                       type: string
                   type: object
                 templateSource:
-                  description: TemplateSource specifies the source field on the generator resource to use as the base for expanded resource. For Pod-creating generators, this is usually spec.template
+                  description: |-
+                    TemplateSource specifies the source field on the generator resource to
+                    use as the base for expanded resource. For Pod-creating generators, this
+                    is usually spec.template
                   type: string
               type: object
             status:
@@ -2357,7 +3156,10 @@ spec:
                           type: string
                         type: array
                       templateUID:
-                        description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                        description: |-
+                          UID is a type that holds unique ID values, including UUIDs.  Because we
+                          don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                          intent and helps make sure that UIDs and names do not get conflated.
                         type: string
                     type: object
                   type: array
@@ -2373,10 +3175,19 @@ spec:
           description: ExpansionTemplate is the Schema for the ExpansionTemplate API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -2384,9 +3195,13 @@ spec:
               description: ExpansionTemplateSpec defines the desired state of ExpansionTemplate.
               properties:
                 applyTo:
-                  description: ApplyTo lists the specific groups, versions and kinds of generator resources which will be expanded.
+                  description: |-
+                    ApplyTo lists the specific groups, versions and kinds of generator resources
+                    which will be expanded.
                   items:
-                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    description: |-
+                      ApplyTo determines what GVKs items the mutation should apply to.
+                      Globs are not allowed.
                     properties:
                       groups:
                         items:
@@ -2403,10 +3218,15 @@ spec:
                     type: object
                   type: array
                 enforcementAction:
-                  description: EnforcementAction specifies the enforcement action to be used for resources matching the ExpansionTemplate. Specifying an empty value will use the enforcement action specified by the Constraint in violation.
+                  description: |-
+                    EnforcementAction specifies the enforcement action to be used for resources
+                    matching the ExpansionTemplate. Specifying an empty value will use the
+                    enforcement action specified by the Constraint in violation.
                   type: string
                 generatedGVK:
-                  description: GeneratedGVK specifies the GVK of the resources which the generator resource creates.
+                  description: |-
+                    GeneratedGVK specifies the GVK of the resources which the generator
+                    resource creates.
                   properties:
                     group:
                       type: string
@@ -2416,7 +3236,10 @@ spec:
                       type: string
                   type: object
                 templateSource:
-                  description: TemplateSource specifies the source field on the generator resource to use as the base for expanded resource. For Pod-creating generators, this is usually spec.template
+                  description: |-
+                    TemplateSource specifies the source field on the generator resource to
+                    use as the base for expanded resource. For Pod-creating generators, this
+                    is usually spec.template
                   type: string
               type: object
             status:
@@ -2448,7 +3271,10 @@ spec:
                           type: string
                         type: array
                       templateUID:
-                        description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                        description: |-
+                          UID is a type that holds unique ID values, including UUIDs.  Because we
+                          don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                          intent and helps make sure that UIDs and names do not get conflated.
                         type: string
                     type: object
                   type: array
@@ -2463,7 +3289,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplatepodstatuses.status.gatekeeper.sh
@@ -2483,10 +3309,19 @@ spec:
           description: ExpansionTemplatePodStatus is the Schema for the expansiontemplatepodstatuses API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -2515,7 +3350,10 @@ spec:
                     type: string
                   type: array
                 templateUID:
-                  description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                  description: |-
+                    UID is a type that holds unique ID values, including UUIDs.  Because we
+                    don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                    intent and helps make sure that UIDs and names do not get conflated.
                   type: string
               type: object
           type: object
@@ -2526,7 +3364,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: modifyset.mutations.gatekeeper.sh
@@ -2543,13 +3381,24 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: ModifySet allows the user to modify non-keyed lists, such as the list of arguments to a container.
+          description: |-
+            ModifySet allows the user to modify non-keyed lists, such as
+            the list of arguments to a container.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               properties:
@@ -2561,9 +3410,14 @@ spec:
               description: ModifySetSpec defines the desired state of ModifySet.
               properties:
                 applyTo:
-                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  description: |-
+                    ApplyTo lists the specific groups, versions and kinds a mutation will be applied to.
+                    This is necessary because every mutation implies part of an object schema and object
+                    schemas are associated with specific GVKs.
                   items:
-                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    description: |-
+                      ApplyTo determines what GVKs items the mutation should apply to.
+                      Globs are not allowed.
                     properties:
                       groups:
                         items:
@@ -2583,21 +3437,40 @@ spec:
                   description: "Location describes the path to be mutated, for example: `spec.containers[name: main].args`."
                   type: string
                 match:
-                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
+                  description: |-
+                    Match allows the user to limit which resources get mutated.
+                    Individual match criteria are AND-ed together. An undefined
+                    match criteria matches everything.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -2608,81 +3481,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -2700,9 +3626,22 @@ spec:
                         - prune
                       type: string
                     pathTests:
-                      description: PathTests are a series of existence tests that can be checked before a mutation is applied
+                      description: |-
+                        PathTests are a series of existence tests that can be checked
+                        before a mutation is applied
                       items:
-                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        description: |-
+                          PathTest allows the user to customize how the mutation works if parent
+                          paths are missing. It traverses the list in order. All sub paths are
+                          tested against the provided condition, if the test fails, the mutation is
+                          not applied. All `subPath` entries must be a prefix of `location`. Any
+                          glob characters will take on the same value as was used to
+                          expand the matching glob in `location`.
+
+
+                          Available Tests:
+                          * MustExist    - the path must exist or do not mutate
+                          * MustNotExist - the path must not exist or do not mutate.
                         properties:
                           condition:
                             description: Condition describes whether the path either MustExist or MustNotExist in the original object
@@ -2736,7 +3675,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -2745,7 +3686,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -2765,13 +3709,24 @@ spec:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: ModifySet allows the user to modify non-keyed lists, such as the list of arguments to a container.
+          description: |-
+            ModifySet allows the user to modify non-keyed lists, such as
+            the list of arguments to a container.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -2779,9 +3734,14 @@ spec:
               description: ModifySetSpec defines the desired state of ModifySet.
               properties:
                 applyTo:
-                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  description: |-
+                    ApplyTo lists the specific groups, versions and kinds a mutation will be applied to.
+                    This is necessary because every mutation implies part of an object schema and object
+                    schemas are associated with specific GVKs.
                   items:
-                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    description: |-
+                      ApplyTo determines what GVKs items the mutation should apply to.
+                      Globs are not allowed.
                     properties:
                       groups:
                         items:
@@ -2801,21 +3761,40 @@ spec:
                   description: "Location describes the path to be mutated, for example: `spec.containers[name: main].args`."
                   type: string
                 match:
-                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
+                  description: |-
+                    Match allows the user to limit which resources get mutated.
+                    Individual match criteria are AND-ed together. An undefined
+                    match criteria matches everything.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -2826,81 +3805,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -2918,9 +3950,22 @@ spec:
                         - prune
                       type: string
                     pathTests:
-                      description: PathTests are a series of existence tests that can be checked before a mutation is applied
+                      description: |-
+                        PathTests are a series of existence tests that can be checked
+                        before a mutation is applied
                       items:
-                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        description: |-
+                          PathTest allows the user to customize how the mutation works if parent
+                          paths are missing. It traverses the list in order. All sub paths are
+                          tested against the provided condition, if the test fails, the mutation is
+                          not applied. All `subPath` entries must be a prefix of `location`. Any
+                          glob characters will take on the same value as was used to
+                          expand the matching glob in `location`.
+
+
+                          Available Tests:
+                          * MustExist    - the path must exist or do not mutate
+                          * MustNotExist - the path must not exist or do not mutate.
                         properties:
                           condition:
                             description: Condition describes whether the path either MustExist or MustNotExist in the original object
@@ -2954,7 +3999,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -2963,7 +4010,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -2983,13 +4033,24 @@ spec:
     - name: v1beta1
       schema:
         openAPIV3Schema:
-          description: ModifySet allows the user to modify non-keyed lists, such as the list of arguments to a container.
+          description: |-
+            ModifySet allows the user to modify non-keyed lists, such as
+            the list of arguments to a container.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -2997,9 +4058,14 @@ spec:
               description: ModifySetSpec defines the desired state of ModifySet.
               properties:
                 applyTo:
-                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  description: |-
+                    ApplyTo lists the specific groups, versions and kinds a mutation will be applied to.
+                    This is necessary because every mutation implies part of an object schema and object
+                    schemas are associated with specific GVKs.
                   items:
-                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    description: |-
+                      ApplyTo determines what GVKs items the mutation should apply to.
+                      Globs are not allowed.
                     properties:
                       groups:
                         items:
@@ -3019,21 +4085,40 @@ spec:
                   description: "Location describes the path to be mutated, for example: `spec.containers[name: main].args`."
                   type: string
                 match:
-                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
+                  description: |-
+                    Match allows the user to limit which resources get mutated.
+                    Individual match criteria are AND-ed together. An undefined
+                    match criteria matches everything.
                   properties:
                     excludedNamespaces:
-                      description: "ExcludedNamespaces is a list of namespace names. If defined, a constraint only applies to resources not in a listed namespace. ExcludedNamespaces also supports a prefix or suffix based glob.  For example, `excludedNamespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        ExcludedNamespaces is a list of namespace names. If defined, a
+                        constraint only applies to resources not in a listed namespace.
+                        ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
+                        `excludedNamespaces: [kube-*]` matches both `kube-system` and
+                        `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
+                        `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     kinds:
                       items:
-                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        description: |-
+                          Kinds accepts a list of objects with apiGroups and kinds fields
+                          that list the groups/kinds of objects to which the mutation will apply.
+                          If multiple groups/kinds objects are specified,
+                          only one match is needed for the resource to be in scope.
                         properties:
                           apiGroups:
-                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            description: |-
+                              APIGroups is the API groups the resources belong to. '*' is all groups.
+                              If '*' is present, the length of the slice must be one.
+                              Required.
                             items:
                               type: string
                             type: array
@@ -3044,81 +4129,134 @@ spec:
                         type: object
                       type: array
                     labelSelector:
-                      description: "LabelSelector is the combination of two optional fields: `matchLabels` and `matchExpressions`.  These two fields provide different methods of selecting or excluding k8s objects based on the label keys and values included in object metadata.  All selection expressions from both sections are ANDed to determine if an object meets the cumulative requirements of the selector."
+                      description: |-
+                        LabelSelector is the combination of two optional fields: `matchLabels`
+                        and `matchExpressions`.  These two fields provide different methods of
+                        selecting or excluding k8s objects based on the label keys and values
+                        included in object metadata.  All selection expressions from both
+                        sections are ANDed to determine if an object meets the cumulative
+                        requirements of the selector.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     name:
-                      description: "Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`."
-                      pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      description: |-
+                        Name is the name of an object.  If defined, it will match against objects with the specified
+                        name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
+                        both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
+                      pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     namespaceSelector:
-                      description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
+                      description: |-
+                        NamespaceSelector is a label selector against an object's containing
+                        namespace or the object itself, if the object is a namespace.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                               - key
                               - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     namespaces:
-                      description: "Namespaces is a list of namespace names. If defined, a constraint only applies to resources in a listed namespace.  Namespaces also supports a prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both `kube-system` and `gatekeeper-system`."
+                      description: |-
+                        Namespaces is a list of namespace names. If defined, a constraint only
+                        applies to resources in a listed namespace.  Namespaces also supports a
+                        prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
+                        `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
+                        `kube-system` and `gatekeeper-system`.
                       items:
-                        description: 'A string that supports globbing at its front or end. Ex: "kube-*" will match "kube-system" or "kube-public", "*-system" will match "kube-system" or "gatekeeper-system".  The asterisk is required for wildcard matching.'
-                        pattern: ^(\*|\*-)?[a-z0-9]([-:a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        description: |-
+                          A string that supports globbing at its front and end. Ex: "kube-*" will match "kube-system" or
+                          "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
+                          match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
+                        pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
                     scope:
-                      description: Scope determines if cluster-scoped and/or namespaced-scoped resources are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
+                      description: |-
+                        Scope determines if cluster-scoped and/or namespaced-scoped resources
+                        are matched.  Accepts `*`, `Cluster`, or `Namespaced`. (defaults to `*`)
                       type: string
                     source:
-                      description: Source determines whether generated or original resources are matched. Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of `Generated` will only match generated resources, while `Original` will only match regular resources.
+                      description: |-
+                        Source determines whether generated or original resources are matched.
+                        Accepts `Generated`|`Original`|`All` (defaults to `All`). A value of
+                        `Generated` will only match generated resources, while `Original` will only
+                        match regular resources.
                       enum:
                         - All
                         - Generated
@@ -3136,9 +4274,22 @@ spec:
                         - prune
                       type: string
                     pathTests:
-                      description: PathTests are a series of existence tests that can be checked before a mutation is applied
+                      description: |-
+                        PathTests are a series of existence tests that can be checked
+                        before a mutation is applied
                       items:
-                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        description: |-
+                          PathTest allows the user to customize how the mutation works if parent
+                          paths are missing. It traverses the list in order. All sub paths are
+                          tested against the provided condition, if the test fails, the mutation is
+                          not applied. All `subPath` entries must be a prefix of `location`. Any
+                          glob characters will take on the same value as was used to
+                          expand the matching glob in `location`.
+
+
+                          Available Tests:
+                          * MustExist    - the path must exist or do not mutate
+                          * MustNotExist - the path must not exist or do not mutate.
                         properties:
                           condition:
                             description: Condition describes whether the path either MustExist or MustNotExist in the original object
@@ -3172,7 +4323,9 @@ spec:
                             message:
                               type: string
                             type:
-                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              description: |-
+                                Type indicates a specific class of error for use by controller code.
+                                If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message
@@ -3181,7 +4334,10 @@ spec:
                       id:
                         type: string
                       mutatorUID:
-                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        description: |-
+                          Storing the mutator UID allows us to detect drift, such as
+                          when a mutator has been recreated after its CRD was deleted
+                          out from under it, interrupting the watch
                         type: string
                       observedGeneration:
                         format: int64
@@ -3203,7 +4359,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: mutatorpodstatuses.status.gatekeeper.sh
@@ -3223,10 +4379,19 @@ spec:
           description: MutatorPodStatus is the Schema for the mutationpodstatuses API.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -3242,7 +4407,9 @@ spec:
                       message:
                         type: string
                       type:
-                        description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                        description: |-
+                          Type indicates a specific class of error for use by controller code.
+                          If not present, the error should be treated as not matching any known type.
                         type: string
                     required:
                       - message
@@ -3251,7 +4418,10 @@ spec:
                 id:
                   type: string
                 mutatorUID:
-                  description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                  description: |-
+                    Storing the mutator UID allows us to detect drift, such as
+                    when a mutator has been recreated after its CRD was deleted
+                    out from under it, interrupting the watch
                   type: string
                 observedGeneration:
                   format: int64
@@ -3269,7 +4439,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: providers.externaldata.gatekeeper.sh
@@ -3291,10 +4461,19 @@ spec:
           description: Provider is the Schema for the Provider API
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -3302,7 +4481,9 @@ spec:
               description: Spec defines the Provider specifications.
               properties:
                 caBundle:
-                  description: CABundle is a base64-encoded string that contains the TLS CA bundle in PEM format. It is used to verify the signature of the provider's certificate.
+                  description: |-
+                    CABundle is a base64-encoded string that contains the TLS CA bundle in PEM format.
+                    It is used to verify the signature of the provider's certificate.
                   type: string
                 timeout:
                   description: Timeout is the timeout when querying the provider.
@@ -3320,10 +4501,19 @@ spec:
           description: Provider is the Schema for the providers API
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -3331,7 +4521,9 @@ spec:
               description: Spec defines the Provider specifications.
               properties:
                 caBundle:
-                  description: CABundle is a base64-encoded string that contains the TLS CA bundle in PEM format. It is used to verify the signature of the provider's certificate.
+                  description: |-
+                    CABundle is a base64-encoded string that contains the TLS CA bundle in PEM format.
+                    It is used to verify the signature of the provider's certificate.
                   type: string
                 timeout:
                   description: Timeout is the timeout when querying the provider.
@@ -3348,7 +4540,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: syncsets.syncset.gatekeeper.sh
@@ -3368,10 +4560,19 @@ spec:
           description: SyncSet defines which resources Gatekeeper will cache. The union of all SyncSets plus the syncOnly field of Gatekeeper's Config resource defines the sets of resources that will be synced.
           properties:
             apiVersion:
-              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               properties:

--- a/katalog/gatekeeper/core/deploy.yml
+++ b/katalog/gatekeeper/core/deploy.yml
@@ -176,6 +176,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: CONTAINER_NAME
               value: manager
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.container.name=$(CONTAINER_NAME)
           image: openpolicyagent/gatekeeper
           imagePullPolicy: Always
           livenessProbe:

--- a/katalog/gatekeeper/core/kustomization.yaml
+++ b/katalog/gatekeeper/core/kustomization.yaml
@@ -23,4 +23,4 @@ resources:
 images:
   - name: openpolicyagent/gatekeeper
     newName: registry.sighup.io/fury/openpolicyagent/gatekeeper
-    newTag: v3.15.1
+    newTag: v3.17.1

--- a/katalog/gatekeeper/core/rbac.yml
+++ b/katalog/gatekeeper/core/rbac.yml
@@ -65,6 +65,19 @@ rules:
       - update
       - watch
   - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions

--- a/katalog/gatekeeper/monitoring/MAINTENANCE.md
+++ b/katalog/gatekeeper/monitoring/MAINTENANCE.md
@@ -1,9 +1,11 @@
 # Gatekeeper Monitoring
 
-All the elements in this folder are tailor made, there's no upstream version to follow.
+All the elements in this folder are tailor-made, there's no upstream version to follow.
 
 Please notice that the alert for "Fail open" webhooks depends on a metric exposed by the Kubernetes API Server ([`apiserver_admission_webhook_fail_open_count`](https://github.com/kubernetes/kubernetes/pull/107171)) that is available since Kubernetes 1.24.
 
 To generate the markdown of the alerts to put in the main readme you can use the following command:
 
-`yq e '.spec.groups[] | .rules[] |  "| " + .alert + " | " + (.annotations.summary // "-" | sub("\n",". "))+ " | " + (.annotations.description // "-" | sub("\n",". ")) + " |"' katalog/gatekeeper/monitoring/alert-rules.yaml`
+```bash
+yq e '.spec.groups[] | .rules[] |  "| " + .alert + " | " + (.annotations.summary // "-" | sub("\n",". "))+ " | " + (.annotations.description // "-" | sub("\n",". ")) + " |"' katalog/gatekeeper/monitoring/alert-rules.yaml
+```

--- a/katalog/gatekeeper/rules/README.md
+++ b/katalog/gatekeeper/rules/README.md
@@ -16,16 +16,16 @@ For example, one could have a `ConstraintTemplate` to check that a set of labels
 
 Below, you can find a list of constraint templates shipped with Kubernetes Fury Distribution:
 
-| Rule Name                  | Desctiption                                                                                                                                           |
-|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Rule Name                  | Description                                                                                                                                           |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `k8slivenessprobe`         | Deny pods that don't declare `livenessProbe`.                                                                                                         |
 | `k8sreadinessprobe`        | Deny pods that don't declare `readinessProbe`.                                                                                                        |
 | `k8suniqueingresshost`     | Deny duplicated ingress across the cluster.                                                                                                           |
 | `k8suniqueserviceselector` | Deny duplicated services selector in the same namespace.                                                                                              |
 | `securitycontrols`         | Deny container images with the `latest` tag, with no limits declared (both CPU and memory), with privilege escalation capability and root containers. |
 
-> [security_controls_template.yml][security-controls-template]: it's an all in one pod security policy measure composed of several rules. Most of the rules are commented out and provided as examples and to be used as starting point for your own rules.
-> This file can be splitted into several `ConstraintTemplates` with the counterpart of having to manage an additional `constraint`/`constraintTemplate` resource for each one.
+> [security_controls_template.yml][security-controls-template]: it's an all-in-one pod security policy measure composed of several rules. Most of the rules are commented out and provided as examples and to be used as starting point for your own rules.
+> This file can be split into several `ConstraintTemplates` with the counterpart of having to manage an additional `constraint`/`constraintTemplate` resource for each one.
 <!-- space left blank on purpose to separate both quotes -->
 > The KFD OPA package provides both `ConstraintTemplates` and `Constraints` for each rule out of the box.
 <!-- space left blank on purpose to separate both quotes -->

--- a/katalog/gatekeeper/rules/kustomization.yaml
+++ b/katalog/gatekeeper/rules/kustomization.yaml
@@ -7,6 +7,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - constraints
   - templates
+  - constraints
   - config

--- a/katalog/tests/gatekeeper.sh
+++ b/katalog/tests/gatekeeper.sh
@@ -22,8 +22,8 @@ set -o pipefail
   info
   deploy() {
     sed -i  -e '/# - DELETE/s/# //g' katalog/gatekeeper/core/vwh.yml
-    kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.14.2/katalog/prometheus-operator/crd-servicemonitor.yml
-    kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.14.2/katalog/prometheus-operator/crd-rule.yml
+    kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/refs/tags/v3.2.0/katalog/prometheus-operator/crds/0servicemonitorCustomResourceDefinition.yaml
+    kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/refs/tags/v3.2.0/katalog/prometheus-operator/crds/0prometheusruleCustomResourceDefinition.yaml
     force_apply katalog/gatekeeper/core
   }
   loop_it deploy 30 2

--- a/katalog/tests/kapp/exists.yaml
+++ b/katalog/tests/kapp/exists.yaml
@@ -1,0 +1,68 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+# ---
+# This manifests are used to tell kapp that the following CRDs will be created
+# by Gatekeeper afterwards and that it is OK that they are not present when
+# running the deploy command.
+# See:
+# - https://github.com/carvel-dev/kapp/blob/develop/examples/gatekeeper-v3.10.0/exists.yml
+# - https://carvel.dev/kapp/docs/v0.63.x/apply-waiting/
+#
+# Below we list all the constraints CRDs that Gatekeeper will be creating.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: k8slivenessprobe.constraints.gatekeeper.sh
+  annotations:
+    kapp.k14s.io/exists: ""
+spec:
+  group: constraints.gatekeeper.sh
+  versions:
+    - name: v1beta1
+  names:
+    kind: K8sLivenessProbe
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: k8sreadinessprobe.constraints.gatekeeper.sh
+  annotations:
+    kapp.k14s.io/exists: ""
+spec:
+  group: constraints.gatekeeper.sh
+  versions:
+    - name: v1beta1
+  names:
+    kind: K8sReadinessProbe
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: k8suniqueingresshost.constraints.gatekeeper.sh
+  annotations:
+    kapp.k14s.io/exists: ""
+spec:
+  group: constraints.gatekeeper.sh
+  versions:
+    - name: v1beta1
+  names:
+    kind: K8sUniqueIngressHost
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: securitycontrols.constraints.gatekeeper.sh
+  annotations:
+    kapp.k14s.io/exists: ""
+spec:
+  group: constraints.gatekeeper.sh
+  versions:
+    - name: v1beta1
+  names:
+    kind: SecurityControls
+---
+


### PR DESCRIPTION
Update OPA Gatekeeper core to v3.17.1, adding compatibility with Kubernetes 1.30 and 1.31.

## Relevant Changes

With the update to 3.17 Gatekeeper now allows:
- 🎓 [Integration with Kubernetes Validating Admission Policy (VAP)](https://open-policy-agent.github.io/gatekeeper/website/docs/validating-admission-policy) is now alpha.
- 🎓 CEL-based policies enforced through Gatekeeper is in beta!
- 🎬 Ability to enforce specific action for Gatekeeper webhook, audit, gator, or VAP in the same constraint through scopedEnforcementActions field under spec in Constraints.

The [VAP](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) integration is very interesting, [it is under a feature gate until Kubernetes 1.30 that enables it by default](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).

Note that there is a change on all the crds, the description field is now a multi line string, but is does not appear to be a change to the contents. You don't need to review them. 

## Upgrade procedure

There are no major changes but some permissions added to the RBAC to be able to generate VAPs from Gatekeeper and the container images tags, of course.

Upgrade is straightforward.

## Note on Kapp

I also added the file `katalog/tests/kapp/exists.yaml` that is needed to deploy the module using Kapp, otherwise Kapp will error out saying that the CRDs that we use for the Constraints do not exist (because they are created by Gatekeeper when it processes the ContraintsTemplates).

