### PR TITLE
fix(kapp): don't recreate Gatekeepers TLS secret content on every apply

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,27 @@
+# OPA Core Module Release vTBD
+
+Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This is a minor release including the following changes:
+
+- [[#114]](https://github.com/sighupio/fury-kubernetes-opa/pull/114) Add kapp `rebaseRule` configuration to avoid replacing Gatekeeper's webhook TLS secret content. Notice that this change applies only when using the module trough `furyctl apply`.
+
+## Component Images 🚢
+
+| Component                   | Supported Version                                                                       | Previous Version |
+| --------------------------- | --------------------------------------------------------------------------------------- | ---------------- |
+| `gatekeeper`                | [`v3.17.1`](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.15.1)       | ``               |
+| `gatekeeper-policy-manager` | [`v1.0.13`](https://github.com/sighupio/gatekeeper-policy-manager/releases/tag/v1.0.13) | ``               |
+| `kyverno`                   | [`v1.12.6`](https://github.com/kyverno/kyverno/releases/tag/v1.12.6)                    | ``               |
+
+> Please refer the individual release notes to get a detailed information on each release.
+
+## Update Guide 🦮
+
+### Process
+
+To upgrade this core module from `v1.13.0` to `vTBD`, you need to download this new version, then apply the `kustomize` project. No further action is required.
+
+```bash
+kustomize build katalog/gatekeeper | kubectl apply -f -
+```

--- a/katalog/tests/kapp/exists.yaml
+++ b/katalog/tests/kapp/exists.yaml
@@ -65,4 +65,15 @@ spec:
   names:
     kind: SecurityControls
 ---
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+rebaseRules:
+  - path: [data]
+    type: copy
+    sources: [existing, new]
+    resourceMatchers:
+      - kindNamespaceNameMatcher:
+          kind: Secret
+          namespace: gatekeeper-system
+          name: gatekeeper-webhook-server-cert
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to knwo that you are working on this change, and let's you have a 
place to track your work in progress.

When opening PRs in Draft, don't assign reviewers until the PR is ready for review.  Once you are confortable with the
status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

<!-- Write a short summary of the changes that this PR introduces and the motivations -->
Add a rebaseRule to the manifests used by kapp to avoid the deletion of the `gatekeeper-webhook-server-cert` secret contents on every apply.

This change will make kapp copy the contents if they exist in the cluster instead of applying the empty content from the manifests.

> [!NOTE]
> This change fixes a bug when applying the module with `kapp`, method used by furyctl since KFD v1.31.0.
> This is not a bug of the OPA module itself.

Closes https://github.com/sighupio/fury-distribution/issues/337

Ref: https://carvel.dev/kapp/docs/v0.64.x/config/#rebaserules

### Description 📝

See the linked issue for more details.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested the change with KFD version 1.31.0
- [x] Clean installation still creates the secret as before.
- [x] Checked logs after a second furyctl apply, the secret is no longer being updated and the content is not deleted anymore.
- [x] Tried deploying a non-compliant workload immediately after a second furyctl apply, it gets properly blocked by Gatekeeper.

### Future work 🔧

None