### PR TITLE
feat: add haproxy, forecastle, and external-dns to whitelists

### DIFF
--- a/katalog/gatekeeper/rules/constraints/patches/all-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/all-matches.yml
@@ -10,6 +10,7 @@
       - logging
       - monitoring
       - ingress-nginx
+      - ingress-haproxy
       - cert-manager
       - tigera-operator
       - calico-system
@@ -17,6 +18,8 @@
       - vmware-system-csi
       - pomerium
       - tracing
+      - forecastle
+      - external-dns
     kinds:
       - apiGroups: ["batch", "extensions", "apps", ""]
         kinds:

--- a/katalog/gatekeeper/rules/constraints/patches/deployment-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/deployment-matches.yml
@@ -10,6 +10,7 @@
       - logging
       - monitoring
       - ingress-nginx
+      - ingress-haproxy
       - cert-manager
       - tigera-operator
       - calico-system
@@ -17,6 +18,8 @@
       - vmware-system-csi
       - pomerium
       - tracing
+      - forecastle
+      - external-dns
     kinds:
       - apiGroups: ["apps", "extensions"]
         kinds: ["Deployment"]

--- a/katalog/gatekeeper/rules/constraints/patches/ingress-matches.yml
+++ b/katalog/gatekeeper/rules/constraints/patches/ingress-matches.yml
@@ -10,12 +10,15 @@
       - logging
       - monitoring
       - ingress-nginx
+      - ingress-haproxy
       - cert-manager
       - tigera-operator
       - calico-system
       - calico-api
       - vmware-system-csi
       - pomerium
+      - forecastle
+      - external-dns
     kinds:
       - apiGroups: ["extensions", "networking.k8s.io"]
         kinds: ["Ingress"]

--- a/katalog/kyverno/MAINTENANCE.values.yaml
+++ b/katalog/kyverno/MAINTENANCE.values.yaml
@@ -21,6 +21,7 @@ config:
           - logging
           - monitoring
           - ingress-nginx
+          - ingress-haproxy
           - cert-manager
           - tigera-operator
           - calico-system
@@ -28,6 +29,8 @@ config:
           - vmware-system-csi
           - pomerium
           - tracing
+          - forecastle
+          - external-dns
 
 # Metrics configuration
 metricsConfig:

--- a/katalog/kyverno/core/deploy.yaml
+++ b/katalog/kyverno/core/deploy.yaml
@@ -278,7 +278,7 @@ data:
     [Secret,kyverno,kyverno-svc.kyverno.svc.*]
     [Secret,kyverno,kyverno-cleanup-controller.kyverno.svc.*]
   updateRequestThreshold: "1000"
-  webhooks: "{\"namespaceSelector\":{\"matchExpressions\":[{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kube-system\",\"kyverno\",\"logging\",\"monitoring\",\"ingress-nginx\",\"cert-manager\",\"tigera-operator\",\"calico-system\",\"calico-api\",\"vmware-system-csi\",\"pomerium\",\"tracing\"]},{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kyverno\"]}],\"matchLabels\":null}}"
+  webhooks: "{\"namespaceSelector\":{\"matchExpressions\":[{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kube-system\",\"kyverno\",\"logging\",\"monitoring\",\"ingress-nginx\",\"ingress-haproxy\",\"cert-manager\",\"tigera-operator\",\"calico-system\",\"calico-api\",\"vmware-system-csi\",\"pomerium\",\"tracing\",\"forecastle\",\"external-dns\"]},{\"key\":\"kubernetes.io/metadata.name\",\"operator\":\"NotIn\",\"values\":[\"kyverno\"]}],\"matchLabels\":null}}"
   webhookAnnotations: "{\"admissions.enforcer/disabled\":\"true\"}"
 ---
 # Source: kyverno/templates/config/metricsconfigmap.yaml


### PR DESCRIPTION
### Summary 💡

<!-- Write a short summary of the changes that this PR introduces and the motivations -->

Add namespace exclusions to policy whitelists for supporting new dedicated namespaces for:
- HAProxy Kubernetes Ingress Controller
- Forecastle
- External DNS

Relates: https://github.com/sighupio/distribution/pull/483


### Description 📝

See above.

### Breaking Changes 💔

<!--
If this PR introduces Breaking Changes, please include all the relevant information:
- What is changing
- What should the process for updating be
- Include examples if you can
-->

None. 

### Tests performed 🧪


- [x] Helm template generates correct the configuration with new namespaces
- [x] Kustomize build succeeds for Kyverno and Gatekeeper
- [x] The deployment will be checked during e2e testing

### Future work 🔧

<!--
If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
this PR can be used as context for that.
-->

None.
