### PR TITLE
docs: refactor module documentation, drop legacy Furyfile flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ### Configuration
 
-The module is deployed with sensible defaults. Configuration is **optional**: you can choose the policy engine and customize its packages under `spec.distribution.modules.policy` in your `furyctl.yaml`. If you omit the block, the defaults are applied.
+You configure the module under `spec.distribution.modules.policy` in your `furyctl.yaml`. The `type` field selects the policy engine to deploy: `gatekeeper`, `kyverno`, or `none` to disable the module. The other fields are optional and fall back to sensible defaults.
 
 ```yaml
 apiVersion: kfd.sighup.io/v1alpha2

--- a/README.md
+++ b/README.md
@@ -13,245 +13,121 @@
 ![License](https://img.shields.io/github/license/sighupio/module-policy?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-**Policy Module** provides policy enforcement at runtime for the [SIGHUP Distribution (SD)][skd-repo].
+**Policy Module** provides runtime policy enforcement for [SIGHUP Distribution (SD)][kfd-repo].
 
-If you are new to SD please refer to the [official documentation][skd-docs] on how to get started with SD.
+If you are new to SD please refer to the [official documentation][kfd-docs] on how to get started with SD.
 
 ## Overview
 
 > [!TIP]
-> [Starting from Kubernetes v1.25][kubernetes-pss-stable], [Pod Security Standards (PSS)][kubernetes-pss] are promoted to stable. For most use cases, the policies defined in the Pod Security Standards are a great starting point, consider applying them before switching to one the of tools provided by this module.
+> [Starting from Kubernetes v1.25][kubernetes-pss-stable], [Pod Security Standards (PSS)][kubernetes-pss] are promoted to stable. For most use cases, the policies defined in the Pod Security Standards are a great starting point; consider applying them before switching to one of the tools provided by this module.
 >
-> For more advanced use-cases, where custom policies that are not included in the PSS must be enforced, this module is the right choice.
+> For more advanced use cases, where custom policies that are not included in the PSS must be enforced, this module is the right choice.
 
-The Kubernetes API server provides a mechanism to review every request that is made (object creation, modification, or deletion). To use this mechanism the API server allows us to create a [Validating Admission Webhook][kubernetes-vaw-docs] that, as the name says, will validate every request and let the API server know if the request is allowed or not based on some logic (policy).
+The Kubernetes API server provides a mechanism to review every request that is made (object creation, modification or deletion) through a [Validating Admission Webhook][kubernetes-vaw-docs] that validates each request and tells the API server whether it is allowed based on some logic (policy).
 
-**Policy Module** module is based on [Gatekeeper][gatekeeper-page] and [Kyverno][kyverno-page], two popular open-source Kubernetes-native policy engines that runs as a Validating Admission Webhook. It allows writing custom constraints (policies) and enforcing them at runtime.
-
-[SIGHUP][sighup-page] provides a set of base constraints that could be used both as a starting point to apply constraints to your current workloads and to give you an idea of how to implement new rules matching your requirements.
+**Policy Module** is based on [Gatekeeper][gatekeeper-page] and [Kyverno][kyverno-page], two popular open-source Kubernetes-native policy engines that run as Validating Admission Webhooks. It allows writing custom constraints (policies) and enforcing them at runtime. [SIGHUP][sighup-page] provides a set of base constraints that can be used both as a starting point and as a reference for implementing new rules matching your requirements.
 
 ## Packages
 
-Policy Module provides the following packages:
+The following packages are included in Policy Module:
 
-| Package                                                | Version   | Description                                                                                                                                             |
+| Package                                                | Version   | Description                                                                                                                                              |
 | ------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Gatekeeper Core](katalog/gatekeeper/core)             | `v3.22.2` | Gatekeeper deployment, ready to enforce rules.                                                                                                          |
 | [Gatekeeper Rules](katalog/gatekeeper/rules)           | `N.A.`    | A set of custom rules to get started with policy enforcement.                                                                                           |
 | [Gatekeeper Monitoring](katalog/gatekeeper/monitoring) | `N.A.`    | Metrics, alerts and dashboard for monitoring Gatekeeper.                                                                                                |
-| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.1.1`  | Gatekeeper Policy Manager, a simple to use web-ui for Gatekeeper.                                                                                       |
-| [Kyverno](katalog/kyverno)                             | `v1.18.1` | Kyverno is a policy engine designed for Kubernetes. It can validate, mutate, and generate configurations using admission controls and background scans. |
+| [Gatekeeper Policy Manager](katalog/gatekeeper/gpm)    | `v1.1.1`  | Gatekeeper Policy Manager, a simple to use web UI for Gatekeeper.                                                                                       |
+| [Kyverno](katalog/kyverno)                             | `v1.18.1` | Kyverno is a policy engine designed for Kubernetes. It can validate, mutate and generate configurations using admission controls and background scans.  |
 
-Click on each package name to see its full documentation.
+Click on each package to see its full documentation.
 
 ## Compatibility
 
 | Kubernetes Version |   Compatibility    | Notes           |
 | ------------------ | :----------------: | --------------- |
-| `1.35.x`           | :white_check_mark: | No known issues |
-| `1.34.x`           | :white_check_mark: | No known issues |
 | `1.33.x`           | :white_check_mark: | No known issues |
+| `1.34.x`           | :white_check_mark: | No known issues |
+| `1.35.x`           | :white_check_mark: | No known issues |
 
-Check the [compatibility matrix][compatibility-matrix] for additional information on previous releases of the module.
+Check the [compatibility matrix][compatibility-matrix] for additional information about previous releases of the module.
 
 ## Usage
 
-> [!NOTE]
-> The following instructions are for using the module with furyctl legacy, or downloading it and using it via kustomize.
->
-> In the latest versions of the SIGHUP Distribution the Policy Module is natively integrated and can be used and configured by the `.spec.distribution.modules.policy` key in the configuration file.
+**Policy Module** is part of SIGHUP Distribution (SD) and is deployed automatically by [`furyctl`][furyctl-repo] when you create or update a cluster. You don't need to download, vendor or install its packages manually.
 
-### Prerequisites
+### Configuration
 
-| Tool                                    | Version    | Description                                                                                                                                                    |
-| --------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]                 | `>=0.27.0` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
-| [kustomize][kustomize-repo]             | `>=3.10.0` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
-| [SD Monitoring Module][skd-monitoring] | `>v1.10.0` | Expose metrics to Prometheus *(optional)* and use Grafana Dashboards.                                                                                          |
-
-> You can comment out the service monitor in the [kustomization.yaml][core-kustomization] file if you don't want to install the monitoring module.
-
-### Gatekeeper deployment
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
+The module is deployed with sensible defaults. Configuration is **optional**: you can choose the policy engine and customize its packages under `spec.distribution.modules.policy` in your `furyctl.yaml`. If you omit the block, the defaults are applied.
 
 ```yaml
-bases:
-  - name: opa/gatekeeper
-    version: "1.17.0"
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      policy:
+        # Select the policy engine: none, gatekeeper or kyverno
+        type: gatekeeper
+        gatekeeper:
+          enforcementAction: deny
+          installDefaultPolicies: true
+          additionalExcludedNamespaces: []
 ```
 
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/opa/gatekeeper`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/opa/gatekeeper` directory as a resource.
+To use Kyverno instead of Gatekeeper, set `type: kyverno` and configure the `kyverno` block:
 
 ```yaml
-resources:
-  - ./vendor/katalog/opa/gatekeeper
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      policy:
+        type: kyverno
+        kyverno:
+          validationFailureAction: Enforce
+          installDefaultPolicies: true
+          additionalExcludedNamespaces: []
 ```
 
-5. Apply the necessary patches. You can find a list of common customization [here](#common-customizations).
+See the configuration reference for your cluster kind for the full list of available options: [EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd] or [OnPremises][schema-reference-onprem].
 
-6. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-> [!WARNING]
-> Gatekeeper is deployed by default as a Fail open (also called `Ignore` mode) Admission Webhook. Should you decide to change it to `Fail` mode read carefully [the project's documentation on the topic first][gatekeeper-failmode].
-<!-- space intentionally left blank -->
-> [!TIP]
-> If you decide to deploy Gatekeeper to a different namespace than the default `gatekeeper-system`, you'll need to patch the file `vwh.yml` to point to the right namespace for the webhook service due to limitations in the `kustomize` tool.
-
-#### Common Customizations
-
-##### Exempting a namespace
-
-Gatekeeper supports 3 levels of granularity to exempt a namespace from policy enforcement.
-
-1. Global exemption at Kubernetes API webhook level: the requests to the API server for the namespace won't be sent to Gatekeeper's webhook.
-2. Global exemption at Gatekeeper configuration level: requests to the API server for the namespace will be sent to Gatekeeper's webhook, but Gatekepeer will not enforce constraints for the namespace. It is the equivalent of exempting the namespace in all the constraints. Useful when you don't want any of the constraints enforced in a namespace.
-3. Exemption at constraint level: you can exempt namespaces in the definition of each constraint. Useful when you may want only a subset of all the constraints to be enforced in a namespace.
-
-> [!CAUTION]
-> Exempting critical namespaces like `kube-system` or `logging` [won't guarantee that the cluster will function properly when Gatekeeper webhook is in `Fail` mode][gatekeeper-failmode].
-
-For more details on how to implement the exemption, please refer to the [official Gatekeeper documentation site][gatekeeper-exemption].
-
-##### Disable constraints
-
-Disable one of the default constraints by creating the following kustomize patch:
-
-```yml
-patchesJson6902:
-    - target:
-          group: constraints.gatekeeper.sh
-          version: v1beta1
-          kind: K8sUniqueIngressHost # replace with the kind of the constraint you want to disable
-          name: unique-ingress-host # replace with the name of the constraint you want to disable
-      path: patches/allow.yml
-```
-
-add this to the `patches/allow.yml` file:
-
-```yml
-- op: "replace"
-  path: "/spec/enforcementaction"
-  value: "allow"
-```
-
-#### Emergency brake
-
-If for some reason Gatekeeper is giving you issues and blocking normal operations in your cluster, you can disable it by removing the Validating Admission Webhook definition from your cluster:
-
-```bash
-kubectl delete ValidatingWebhookConfiguration gatekeeper-validating-webhook-configuration
-```
-
-#### Monitoring
-
-Gatekeeper is configured by default in this module to expose some Prometheus metrics about its health, performance, and operative information.
-
-You can monitor and review these metrics by checking out the provided Grafana dashboard. (This requires the SD Monitoring Module to be installed).
-
-Go to your cluster's Grafana and search for the "Gatekeeper" dashboard:
-
-<!-- markdownlint-disable MD033 -->
-
-<a href="docs/images/screenshots/grafana-dashboard.png"><img src="docs/images/screenshots/grafana-dashboard.png" width="250"/></a>
-
-<!-- markdownlint-enable MD033 -->
-
-You can also use [Gatekeeper Policy Manager](katalog/gatekeeper/gpm/README.md) to view the Constraints Templates, Constraints, and Violations in a simple-to-use UI.
-
-
-<!-- markdownlint-disable MD033 -->
-
-<a href="docs/images/screenshots/gpm-screenhost.png"><img src="docs/images/screenshots/gpm-screenhost.png" width="250"/></a>
-
-<!-- markdownlint-enable MD033 -->
-
-Two alerts are also provided by default with the module, the alerts are triggered when the number of errors seen by the Kubernetes API server trying to contact Gatekeeper's webhook is too high. Both for Fail open (`Ignore`) mode and Fail mode:
-
-| Alert                         | Description                                                                                                                                 |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| GatekeeperWebhookFailOpenHigh | Gatekeeper is not enforcing {{$labels.type}} requests to the API server.                                                                    |
-| GatekeeperWebhookCallError    | Kubernetes API server is rejecting all requests because Gatekeeper's webhook '{{ $labels.name }}' is failing for '{{ $labels.operation }}'. |
-
-Notice that the alert for when the Gatekeeper webhook is in `Ignore` mode (the default) depends on an API server metric that has been added in Kubernetes version 1.24. Previous versions of Kubernetes won't trigger alerts when the webhook is failing and in `Ignore` mode.
-
-### Kyverno deployment
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
-
-```yaml
-bases:
-  - name: opa/kyverno
-    version: "1.17.0"
-```
-
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/opa/kyverno`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/opa/kyverno` directory as a resource.
-
-```yaml
-resources:
-  - ./vendor/katalog/opa/kyverno
-```
-
-5. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply --server-side -f -
-```
+To install SD from scratch, follow the [Getting started][getting-started] guide.
 
 <!-- Links -->
 
 [kubernetes-pss-stable]: https://kubernetes.io/blog/2022/08/25/pod-security-admission-stable/
 [kubernetes-pss]: https://kubernetes.io/docs/concepts/security/pod-security-standards/
-
-[gatekeeper-page]: https://github.com/open-policy-agent/gatekeeper
-[gatekeeper-failmode]: https://open-policy-agent.github.io/gatekeeper/website/docs/failing-closed/
-[gatekeeper-exemption]: https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces/
-
-[kyverno-page]: https://github.com/kyverno/kyverno
 [kubernetes-vaw-docs]: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
-
-[core-kustomization]: ./katalog/gatekeeper/core/kustomization.yaml
+[gatekeeper-page]: https://github.com/open-policy-agent/gatekeeper
+[kyverno-page]: https://github.com/kyverno/kyverno
+[sighup-page]: https://sighup.io
+[kfd-repo]: https://github.com/sighupio/distribution
+[furyctl-repo]: https://github.com/sighupio/furyctl
+[kfd-docs]: https://docs.sighup.io/docs/distribution/
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulespolicy
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulespolicy
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulespolicy
+[getting-started]: https://docs.sighup.io/docs/getting-started/
 [compatibility-matrix]: https://github.com/sighupio/module-policy/blob/main/docs/COMPATIBILITY_MATRIX.md
 
-[sighup-page]: https://sighup.io
-[skd-repo]: https://github.com/sighupio/distribution
-[skd-docs]: https://docs.kubernetesfury.com/docs/distribution/
-[skd-monitoring]: https://github.com/sighupio/module-monitoring
-[furyctl-repo]: https://github.com/sighupio/furyctl
-[kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
-
-<!-- </KFD-DOCS> -->
+<!-- </SD-DOCS> -->
 
 <!-- <FOOTER> -->
 
 ## Contributing
 
-Before contributing, please read the [Contributing Guidelines](docs/CONTRIBUTING.md).
+Before contributing, please read first the [Contributing Guidelines](https://github.com/sighupio/distribution/blob/main/docs/CONTRIBUTING.md).
 
 ### Reporting Issues
 
-In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/module-policy/issues/new/choose).
+In case you experience any problem with the module, please [open a new issue](https://github.com/sighupio/module-policy/issues/new/choose).
 
 ## License
 
-This module is open-source and released under the following [LICENSE](LICENSE)
+This module is open-source and it's released under the following [LICENSE](LICENSE).
 
 <!-- </FOOTER> -->

--- a/katalog/gatekeeper/README.md
+++ b/katalog/gatekeeper/README.md
@@ -1,133 +1,37 @@
 # Gatekeeper
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-## Requirements
+## Overview
 
-Minimum Kubernetes version `>=v1.18` with the API server `ValidatingAdmissionWebhook` plugin enabled.
+Gatekeeper is a Kubernetes-native policy engine, built on top of the Open Policy Agent (OPA), that runs as a Validating Admission Webhook to enforce policies (constraints) at runtime. In the Policy Module it is one of the two selectable policy engines and ships with a set of SIGHUP base constraints, a monitoring integration and the Gatekeeper Policy Manager web UI.
 
-Gatekeeper core package gets deployed by default with the following resource limits:
+This directory groups the Gatekeeper packages:
 
-- CPU: 1000m
-- Memory: 512Mi
+- [`core`](core) — the Gatekeeper deployment, ready to enforce rules.
+- [`rules`](rules) — the SIGHUP base set of `ConstraintTemplates` and `Constraints`.
+- [`monitoring`](monitoring) — `ServiceMonitor`, Prometheus rules and Grafana dashboard.
+- [`gpm`](gpm) — Gatekeeper Policy Manager, a read-only web UI for Gatekeeper.
 
-Gatekeeper Policy Manager package gets deployed by default with the following resource limits:
+## Upstream project
 
-- CPU: 500m
-- Memory: 256Mi
+This package is based on the upstream [Gatekeeper][gatekeeper-github].
 
-## Fury Setup
+## Deployment
 
-This module can easily be added to your existing Fury setup adding to your `Furyfile.yml`:
+This package is deployed as part of **Policy Module** when you create a cluster with `furyctl` and `spec.distribution.modules.policy.type` is set to `gatekeeper`.
 
-```yaml
-bases:
-  (...)
-  - name: opa/gatekeeper
-    version: "v1.16.0"
-```
-
-Once you'll do this, you can then proceed to integrate Gatekeeper into your Kustomize project.
-
-### Disable constraints
-
-If you need to disable already existing constraints that are usually enabled by default,
-you can just simply create a patch in Kustomize like the following one:
-
-```yaml
-patchesJson6902:
-    - target:
-          group: constraints.gatekeeper.sh
-          version: v1beta1
-          kind: K8sUniqueIngressHost # is just an example of already enabled constraints
-          name: unique-ingress-host
-      path: patches/dryrun.yml
-```
-
-in the `patches/allow.yml`:
-
-```yaml
-- op: "replace"
-  path: "/spec/enforcementAction"
-  value: "dryrun"
-```
-
-### Exclude namespaces from gatekeeper constraints
-
-There are already a bunch of namespaces excluded by default by the rules of Gatekeeper, that are the ones
-used by infra namespaces *(logging, monitoring, kube-system, ingress-nginx)*. If this subset must be modified for whatever
-reason, you can just do it with a kustomize path like the following one:
-
-```yaml
-patchesJson6902:
-    - target:
-          group: constraints.gatekeeper.sh
-          version: v1beta1
-          kind: K8sUniqueIngressHost # is just an example of already enabled constraints
-          name: unique-ingress-host
-      path: patches/ns.yml
-```
-
-in the `patches/allow.yml`:
-
-```yaml
-- op: "replace"
-  path: "/spec/match/excludedNamespaces"
-  value:
-      - my-ns-1
-      - my-ns-2
-      - my-ns-3
-      - my-ns-4
-```
-
-### The naming of Constraints and ConstraintTemplates
-
-To be more explicit, it is useful to give a verbose name to constraints, such as `all_pod_must_have_gatekeeper_namespaceselector.yml`.
-In this way, the scope of the constraint that is going to be applied will be crystal clear.
-
-For the `ConstraintTemplate` (that is the general logic — a function basically —) could be reasonable to have something
-like: `k8srequiredlabels_template.yml`
-
-#### Uninstall Constraints
-
-To uninstall rules you first need to remove the `Constraint`, then the `constraintTemplate`:
-
-here is an example of the following resource:
-
-```bash
-kubectl delete crd k8scontainerlimits.constraints.gatekeeper.sh # this will remove the constraint
-kubectl delete constrainttemplates.templates.gatekeeper.sh k8scontainerlimits # this will remove the constraintTemplate
-```
-
-### Modify constraintTemplates rules (securityControls)
-
-There is a `constraintTemplate` *(`securityControl`)* that enables only a few subsets of the available rules, basically
-because there are a lot of rules that require pretty much effort to achieve them. If you want to enable them, you can
-just make a patch with kustomize (following the examples above) and enable a part or all of them
-(you can find them here: [security_controls_template.yml](rules/templates/security_controls_template.yml)
-
-## Uninstallation
-
-Before uninstalling Gatekeeper, be sure to clean up old `Constraints`, `ConstraintTemplates`, and
-the `Config` resource in the `gatekeeper-system` namespace. This will make sure all finalizers
-are removed by Gatekeeper. Otherwise, the finalizers will need to be removed manually.
-
-### Before Uninstall, Clean Up Old Constraints
-
-Currently, the uninstallation mechanism only removes the Gatekeeper system,
-it does not remove any `ConstraintTemplate`, `Constraint`, and `Config` resources that have been created by the user,
-nor does it remove their accompanying `CRDs`.
-
-When Gatekeeper is running it is possible to remove unwanted constraints by:
-
-- Deleting all instances of the constraint resource.
-- Deleting the `ConstraintTemplate` resource, which should automatically clean up the `CRD`.
-- Deleting the `Config` resource removes finalizers on synced resources.
-
-For more details please refer to [Gatekeeper's official repository][gatekeeper-repo] and the [official Gatekeeper documentation site][gatekeeper-docs].
+You can customize it under `spec.distribution.modules.policy.gatekeeper` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
-[gatekeeper-repo]: https://github.com/open-policy-agent/gatekeeper
-[gatekeeper-docs]: https://open-policy-agent.github.io/gatekeeper/website/docs/
 
-<!-- </KFD-DOCS> -->
+[gatekeeper-github]: https://github.com/open-policy-agent/gatekeeper
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulespolicy
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulespolicy
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulespolicy
+
+<!-- </SD-DOCS> -->
+
+## License
+
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/gatekeeper/gpm/README.md
+++ b/katalog/gatekeeper/gpm/README.md
@@ -1,207 +1,25 @@
-<!-- markdownlint-disable MD033 -->
-<h1>
-    <img src="docs/assets/logo.svg" align="left" width="90" style="margin-right: 15px"/>
-    Gatekeeper Policy Manager (GPM)
-</h1>
-<!-- markdownlint-enable MD033 -->
+# Gatekeeper Policy Manager (GPM)
 
-[![Build Status](https://ci.sighup.io/api/badges/sighupio/gatekeeper-policy-manager/status.svg)](https://ci.sighup.io/sighupio/gatekeeper-policy-manager)
-![GPM Release](https://img.shields.io/badge/GPM-v1.1.0-blue)
-![Helm Chart Release](https://img.shields.io/badge/Helm%20Chart-v0.4.1-blue)
-![License](https://img.shields.io/github/license/sighupio/gatekeeper-policy-manager)
+<!-- <SD-DOCS> -->
 
-**Gatekeeper Policy Manager** is a simple *read-only* web UI for viewing OPA Gatekeeper policies' status in a Kubernetes Cluster.
+## Overview
 
-The target Kubernetes Cluster can be the same where GPM is running or some other [remote cluster(s) using a `kubeconfig` file](#multi-cluster-support). You can also run GPM [locally in a client machine](#running-locally) and connect to a remote cluster.
+Gatekeeper Policy Manager (GPM) is a simple, read-only web UI for viewing the status of OPA Gatekeeper policies in a Kubernetes cluster. It can display all the defined `ConstraintTemplates` with their rego code, the Gatekeeper configuration CRDs, and all the `Constraints` with their current status, violations, enforcement action and match definitions.
 
-GPM can display all the defined **Constraint Templates** with their rego code, all the Gatekeeper Configuration CRDs, and all the **Constraints** with their current status, violations, enforcement action, matches definitions, etc.
+## Upstream project
 
-[You can see some screenshots below](#screenshots).
+This package is based on the upstream [Gatekeeper Policy Manager][gpm-github].
 
-## Requirements
+## Deployment
 
-You'll need OPA Gatekeeper running in your cluster and at least some constraint templates and constraints defined to take advantage of this tool.
+This package is deployed as part of **Policy Module** when you create a cluster with `furyctl` and `spec.distribution.modules.policy.type` is set to `gatekeeper`. See the [module documentation](../../../README.md) to learn how the Policy Module is installed and configured.
 
-> [!NOTE]
-> You can easily deploy Gatekeeper to your cluster using the (also open source) [SIGHUP Distribution Policy Module](https://github.com/sighupio/module-policy).
+<!-- Links -->
 
-## Deploying GPM
+[gpm-github]: https://github.com/sighupio/gatekeeper-policy-manager
 
-### Deploy using Kustomize
+<!-- </SD-DOCS> -->
 
-To deploy Gatekeeper Policy Manager to your cluster, apply the provided [`kustomization`](kustomization.yaml) file running the following command:
+## License
 
-```shell
-kubectl apply -k .
-```
-
-By default, this will create a deployment and a service both with the name `gatekeper-policy-manager` in the `gatekeeper-system` namespace. We invite you to take a look into the `kustomization.yaml` file to do further configuration.
-
-> The app can be run as a POD in a Kubernetes cluster or locally with a `kubeconfig` file. It will try its best to autodetect the correct configuration.
-
-Once you've deployed the application, if you haven't set up an ingress, you can access the web-UI using port-forward:
-
-```bash
-kubectl -n gatekeeper-system port-forward  svc/gatekeeper-policy-manager 8080:80
-```
-
-Then access it with your browser on: [http://127.0.0.1:8080](http://127.0.0.1:8080)
-
-### Deploy using Helm
-
-It is also possible to deploy GPM using the [provided Helm Chart](./chart).
-
-First create a values file, for example `my-values.yaml`, with your custom values for the release. See the [chart's readme](./chart/README.md) and the [default values.yaml](./chart/values.yaml) for more information.
-
-Then, execute:
-
-```bash
-helm repo add gpm https://sighupio.github.io/gatekeeper-policy-manager
-helm upgrade --install --namespace gatekeeper-system --set image.tag=v1.1.0 --values my-values.yaml gatekeeper-policy-manager gpm/gatekeeper-policy-manager
-```
-
-> [!IMPORTANT]
-> Don't forget to replace `my-values.yaml` with the path to your values file.
-
-## Running locally
-
-GPM can also be run locally using docker and a `kubeconfig`, assuming that the `kubeconfig` file you want to use is located at `~/.kube/config` the command to run GPM locally would be:
-
-```bash
-docker run -v ~/.kube/config:/home/gpm/.kube/config -p 8080:8080 quay.io/sighup/gatekeeper-policy-manager:v1.1.0
-```
-
-Then access it with your browser on: [http://127.0.0.1:8080](http://127.0.0.1:8080)
-
-> You can also run the flask app directly, see the [development section](#development) for further information.
-
-## Configuration
-
-GPM is a stateless application, but it can be configured using environment variables. The possible configurations are:
-
-| Environment Variable Name         | Description                                                                                                                                                                                                                       | Default                |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `GPM_SECRET_KEY`                  | The secret key used to generate tokens. **Change this value in production**.                                                                                                                                                      | `g8k1p3rp0l1c7m4n4g3r` |
-| `KUBECONFIG`                      | Path to a [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file, if provided while running inside a cluster this configuration file will be used instead of the cluster's API. |
-| `GPM_LOG_LEVEL`                   | Log level (see [python logging docs](https://docs.python.org/2/library/logging.html#levels) for available levels)                                                                                                                 | `INFO`                 |
-| `GPM_AUTH_ENABLED`                | Enable Authentication current options: "Anonymous", "OIDC"                                                                                                                                                                        | Anonymous              |
-| `GPM_PREFERRED_URL_SCHEME`        | URL scheme to be used while generating links.                                                                                                                                                                                     | `http`                 |
-| `GPM_OIDC_REDIRECT_DOMAIN`        | The domain where GPM is being running. This is where the client will be redirected after authenticating                                                                                                                           |                        |
-| `GPM_OIDC_CLIENT_ID`              | The Client ID used to authenticate against the OIDC Provider                                                                                                                                                                      |                        |
-| `GPM_OIDC_CLIENT_SECRET`          | The Client Secret used to authenticate against the OIDC Provider (optional)                                                                                                                                                       |                        |
-| `GPM_OIDC_ISSUER`                 | OIDC Issuer hostname (required if OIDC Auth is enabled)                                                                                                                                                                           |                        |
-| `GPM_OIDC_AUTHORIZATION_ENDPOINT` | OIDC Authorization Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                |                        |
-| `GPM_OIDC_JWKS_URI`               | OIDC JWKS URI (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                              |                        |
-| `GPM_OIDC_TOKEN_ENDPOINT`         | OIDC TOKEN Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                        |                        |
-| `GPM_OIDC_INTROSPECTION_ENDPOINT` | OIDC Introspection Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                |                        |
-| `GPM_OIDC_USERINFO_ENDPOINT`      | OIDC Userinfo Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                     |                        |
-| `GPM_OIDC_END_SESSION_ENDPOINT`   | OIDC End Session Endpoint (optional, setting this parameter disables the discovery of the rest of the provider configuration, set all the other values also if setting this one)                                                  |                        |
-
->[!WARNING]
-> Please notice that OIDC Authentication is in beta state. It has been tested to work with Keycloak as a provider.
->
-> These environment variables are already provided and ready to be set in the [`manifests/enable-oidc.yaml`](manifests/enable-oidc.yaml) file.
-
-### Multi-cluster support
-
-GPM has multi-cluster support when using a `kubeconfig` with more than one context. GPM will let you chose the context right from the UI.
-
-If you want to run GPM in-cluster but with multi-cluster support, it's as easy as mounting a `kubeconfig` file in GPM's pod(s) with the cluster access configuration and set the environment variable `KUBECONFIG` with the path to the mounted `kubeconfig` file. Or you can simply mount it in `/home/gpm/.kube/config` and GPM will detect it automatically.
-
-> [!NOTE]
-> Please remember that the user for the clusters should have the right permissions. You can use the [`manifests/rabc.yaml`](manifests/rbac.yaml) file as reference.
->
-> Also note that the cluster where GPM is running should be able to reach the other clusters.
-
-When you run GPM locally, you are already using a `kubeconfig` file to connect to the clusters, now you should see all your defined contexts. You can switch between them easily from the UI.
-
-#### AWS IAM Authentication
-
-If you want to use a Kubeconfig with IAM Authentication, you'll need to customize GPM's container image because the IAM authentication uses external AWS binaries that are not included by default in the image.
-
-You can customize the container image with a `Dockerfile` like the following:
-
-```Dockerfile
-FROM curlimages/curl:7.81.0 as downloader
-RUN curl https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.5/aws-iam-authenticator_0.5.5_linux_amd64 --output /tmp/aws-iam-authenticator
-RUN chmod +x /tmp/aws-iam-authenticator
-FROM quay.io/sighup/gatekeeper-policy-manager:v1.1.0
-COPY --from=downloader --chown=root:root /tmp/aws-iam-authenticator /usr/local/bin/
-```
-
-You may need to add also the `aws` CLI, you can use the same approach as before.
-
-Make sure that your `kubeconfig` has the `apiVersion` set as `client.authentication.k8s.io/v1beta1`
-
-You can read more [in this issue](https://github.com/sighupio/gatekeeper-policy-manager/issues/330).
-
-## Screenshots
-
-![welcome](screenshots/01-home.png)
-
-![Constraint Templates view](screenshots/02-constrainttemplates.png)
-
-![Constraint Templates view rego code](screenshots/03-constrainttemplates.png)
-
-![Constraint view](screenshots/04-constraints.png)
-
-![Constraint view 2](screenshots/05-constraints.png)
-
-![Constraint Report 3](screenshots/06-constraints.png)
-
-![Configurations view 2](screenshots/07-configs.png)
-
-![Cluster Selector](screenshots/08-multicluster.png)
-
-## Development
-
-GPM is written in Python using the Flask framework for the backend and React with Elastic UI and the Fury theme for the frontend.
-
-To develop GPM, you'll need to create a Python 3 virtual environment, install all the dependencies specified in the provided `requirements.txt`, build the react frontend and you are good to start hacking.
-
-The following commands should get you up and running:
-
-```bash
-# Build frontend and copy over to static folder
-$ pushd app/web-client
-$ yarn install && yarn build
-$ cp -r build/* ../static-content/
-$ popd
-# Create a virtualenv
-$ python3 -m venv env
-# Activate it
-$ source ./env/bin/activate
-# Install all the dependencies
-$ pip install -r app/requirements.txt
-# Run the development server
-$ FLASK_APP=app/app.py FLASK_ENV=development flask run
-```
-
-If you want to test changes to the frontend live, make sure the backend is running (see above) and then run the frontend using `yarn`:
-
-```bash
-cd app/web-client
-yarn start
-```
-
-A browser window should open, if the React application can't reach the backend, check that the `.env` file points to the right backend endpoint (`REACT_APP_LOCAL_GPM_SERVER_URL`).
-
-> [!TIP]
-> Access to a Kubernetes cluster with OPA Gatekeeper deployed is recommended to debug the application.
->
-> You'll need an OIDC provider to test the OIDC authentication. You can use the SIGHUP Distribution [Keycloak add-on module](https://github.com/sighupio/add-on-keycloak).
-
-## Roadmap
-
-The following is a wishlist of features that we would like to add to GPM (in no particular order):
-
-- [x] List the constraints that are currently using a `ConstraintTemplate`
-- [ ] Polished OIDC authentication
-- [ ] LDAP authentication
-- [x] Better syntax highlighting for the rego code snippets
-- [x] Root-less docker image
-- [x] Multi-cluster view
-- [ ] Minimal write capabilities?
-- [ ] Rewrite app in Golang? (WIP in the `feature/go-backend` branch)
-
-Please, let us know if you are using GPM and what features would you like to have by creating an issue here on GitHub 💪🏻
+For license details please see [LICENSE](../../../LICENSE)

--- a/katalog/gatekeeper/monitoring/README.md
+++ b/katalog/gatekeeper/monitoring/README.md
@@ -1,11 +1,23 @@
-# Monitoring
+# Gatekeeper Monitoring
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-This package includes:
+## Overview
 
-- a Prometheus `ServiceMonitor` definition to instruct the SD Monitoring module to gather the metrics from Gatekeeper
-- a custom set of Prometheus rules to alert when Gatekeeper's webhooks are misbehaving
-- a custom Grafana Dashboard that shows the mentioned metrics in a nice visual way.
+This package provides the monitoring integration for Gatekeeper. It includes:
 
-<!-- </KFD-DOCS> -->
+- a Prometheus `ServiceMonitor` definition to instruct the SD Monitoring Module to gather Gatekeeper metrics;
+- a custom set of Prometheus rules to alert when Gatekeeper's webhooks are misbehaving;
+- a custom Grafana dashboard that visualizes those metrics.
+
+It requires the SD Monitoring Module to be installed.
+
+## Deployment
+
+This package is deployed as part of **Policy Module** when you create a cluster with `furyctl` and `spec.distribution.modules.policy.type` is set to `gatekeeper`. See the [module documentation](../../../README.md) to learn how the Policy Module is installed and configured.
+
+<!-- </SD-DOCS> -->
+
+## License
+
+For license details please see [LICENSE](../../../LICENSE)

--- a/katalog/gatekeeper/rules/README.md
+++ b/katalog/gatekeeper/rules/README.md
@@ -1,66 +1,42 @@
 # Gatekeeper Rules
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-A Policy is a group of rules that enforce desired behavior. The module provides a set of common policies out of the box to get started in securing your cluster.
+## Overview
 
-A policy in Gatekeeper is defined by two objects: a `ConstraintTemplate` and a `Constraint`.
+A policy is a group of rules that enforce a desired behavior. This package provides a set of common policies out of the box to get started in securing your cluster. A policy in Gatekeeper is defined by two objects: a `ConstraintTemplate`, which defines the common logic of the policy, and a `Constraint`, which instantiates that logic with the right values for the required parameters.
 
-As the name suggests, the `ConstraintTemplate` defines the common logic of the policy and the `Constraint` takes that logic and creates the actual policy by creating an instance of the template with the right values for the required parameters.
+All the `Constraints` exclude the SD "infra" namespaces (`kube-system`, `logging`, `monitoring`, `ingress-nginx`, `cert-manager`) by default to avoid service disruption.
 
-For example, one could have a `ConstraintTemplate` to check that a set of labels are present. But, what particular labels to check could be a parameter of the template that should be configured in the `Constraint`. Let's say that the `Constraint` will check that the label `application-group: FURY` should be present for deployments in a defined namespace.
+The following constraint templates ship with SIGHUP Distribution:
 
-> For a more detailed explanation, please refer to [Gatekeeper's official documentation][gatekeeper-docs].
-
-## SIGHUP base rules
-
-Below, you can find a list of constraint templates shipped with SIGHUP Distribution:
-
-| Rule Name                  | Description                                                                                                                                           |
+| Rule Name                  | Description                                                                                                                                            |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `k8slivenessprobe`         | Deny pods that don't declare `livenessProbe`.                                                                                                         |
-| `k8sreadinessprobe`        | Deny pods that don't declare `readinessProbe`.                                                                                                        |
-| `k8suniqueingresshost`     | Deny duplicated ingress across the cluster.                                                                                                           |
+| `k8slivenessprobe`         | Deny pods that don't declare `livenessProbe`.                                                                                                          |
+| `k8sreadinessprobe`        | Deny pods that don't declare `readinessProbe`.                                                                                                         |
+| `k8suniqueingresshost`     | Deny duplicated ingress across the cluster.                                                                                                            |
 | `k8suniqueserviceselector` | Deny duplicated services selector in the same namespace.                                                                                              |
 | `securitycontrols`         | Deny container images with the `latest` tag, with no limits declared (both CPU and memory), with privilege escalation capability and root containers. |
 
-> [security_controls_template.yml][security-controls-template]: it's an all-in-one pod security policy measure composed of several rules. Most of the rules are commented out and provided as examples and to be used as starting point for your own rules.
-> This file can be split into several `ConstraintTemplates` with the counterpart of having to manage an additional `constraint`/`constraintTemplate` resource for each one.
-<!-- space left blank on purpose to separate both quotes -->
-> The Gatekeeper package provides both `ConstraintTemplates` and `Constraints` for each rule out of the box.
-<!-- space left blank on purpose to separate both quotes -->
-> All the `Constraints` exclude by default SD "infra" namespaces (`kube-system`, `logging`, `monitoring`, `ingress-nginx`, `cert-manager`) to avoid service disruption.
+## Upstream project
 
-### Usage
+This package is based on the upstream [Gatekeeper][gatekeeper-github] and on the SIGHUP base constraint library.
 
-Creating a constraint from a SIGHUP base constraint template is done by declaring a new CRD, for example, the following `Constraint` will check that all `Deployments` have a liveness probe defined in all namespaces except in `kube-system` and deny the creation of the ones that do not have it:
+## Deployment
 
-```yaml
----
-apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: K8sLivenessProbe
-metadata:
-  name: liveness-probe
-spec:
-  enforcementAction: deny
-  match:
-    excludedNamespaces:
-      - kube-system
-    kinds:
-      - apiGroups: ["apps", "extensions"]
-        kinds: ["Deployment"]
-```
+This package is deployed as part of **Policy Module** when you create a cluster with `furyctl` and `spec.distribution.modules.policy.type` is set to `gatekeeper`.
 
-ℹ️ change `enforcementAction` value to `dryrun` first and look into the audit logs to understand if your constraint is working as expected without blocking anything. Once you are sure, you can set the `Constraint` to `deny` and start blocking.
-
-ℹ️ take a look at [Gatekeeper Policy Manager][gpm] if you want to see the status of your constraints (and more) in a nice web UI.
-
-> Please refer to [the official documentation][gatekeeper-constraint-docs] to better understand how to create `Constraints`.
+You can control whether the default policies are installed and customize enforcement under `spec.distribution.modules.policy.gatekeeper` in your `furyctl.yaml`. See the [module documentation](../../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
-[security-controls-template]: templates/security_controls_template.yml
-[gatekeeper-docs]: https://open-policy-agent.github.io/gatekeeper/website/docs/
-[gatekeeper-constraint-docs]: https://open-policy-agent.github.io/gatekeeper/website/docs/howto#constraints
-[gpm]: ../gpm/
 
-<!-- </KFD-DOCS> -->
+[gatekeeper-github]: https://github.com/open-policy-agent/gatekeeper
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulespolicy
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulespolicy
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulespolicy
+
+<!-- </SD-DOCS> -->
+
+## License
+
+For license details please see [LICENSE](../../../LICENSE)

--- a/katalog/kyverno/README.md
+++ b/katalog/kyverno/README.md
@@ -1,59 +1,47 @@
 # Kyverno
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-Kyverno is a policy engine designed for Kubernetes. It can validate, mutate, and generate configurations using admission controls and background scans. Kyverno policies are Kubernetes resources and do not require learning a new language. Kyverno is designed to work nicely with tools you already use like kubectl, kustomize, and Git.
+## Overview
 
-## Requirements
+Kyverno is a policy engine designed for Kubernetes. It can validate, mutate and generate configurations using admission controls and background scans. Kyverno policies are Kubernetes resources and do not require learning a new language. In the Policy Module it is one of the two selectable policy engines, deployed in HA mode and excluding the SD `infra` namespaces from its webhooks by default.
 
-- Kubernetes >= `1.25.0`
-- Kustomize >= `v3.5.3`
+This package ships a set of predefined policies that form the SD baseline, similar to what is provided with the Gatekeeper package:
 
-## Image repositories
+| Policy                         | Description                                                                                                                                  |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| disallow-capabilities-strict   | Adding capabilities other than `NET_BIND_SERVICE` is disallowed; all containers must explicitly drop `ALL` capabilities.                    |
+| disallow-capabilities          | Adding capabilities beyond those listed in the policy is disallowed.                                                                         |
+| disallow-host-namespaces       | Pods should not be allowed access to host namespaces (PID, IPC, network).                                                                   |
+| disallow-host-path             | Ensures no `hostPath` volumes are in use.                                                                                                    |
+| disallow-host-ports            | Ensures the `hostPort` field is unset or set to `0`.                                                                                        |
+| disallow-latest-tag            | Validates that images specify a tag and that it is not `latest`.                                                                            |
+| disallow-privilege-escalation  | Ensures the `allowPrivilegeEscalation` field is set to `false`.                                                                             |
+| disallow-privileged-containers | Ensures Pods do not run in privileged mode.                                                                                                  |
+| disallow-proc-mount            | Ensures nothing but the default `procMount` can be specified.                                                                               |
+| require-pod-probes             | Liveness and readiness probes must be configured.                                                                                           |
+| require-run-as-nonroot         | Ensures `runAsNonRoot` is set to `true`.                                                                                                    |
+| restrict-sysctls               | Disallows sysctls except for an allowed "safe" subset.                                                                                       |
+| unique-ingress-host-and-path   | Ensures Ingresses are globally unique with respect to the host plus path combination.                                                       |
 
-- registry.sighup.io/fury/kyverno/kyverno
-- registry.sighup.io/fury/kyverno/kyvernopre
-- registry.sighup.io/fury/kyverno/background-controller
-- registry.sighup.io/fury/kyverno/cleanup-controller
-- registry.sighup.io/fury/kyverno/reports-controller
-- registry.sighup.io/fury/bitnami/kubectl
+## Upstream project
 
-## Configuration
-
-Kyverno is deployed in HA mode, and whitelists the SD `infra` namespaces by default on the webhooks.
-
-## Pre-configured policies
-
-This package comes with a set of predefined policies from the main kyverno repository. These policies are our own SD baseline, and are similar to what is provided with the Gatekeeper package.
-
-| Policy                         | Description                                                                                                                                                                                                                                                                                                                          |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| disallow-capabilities-strict   | Adding capabilities other than `NET_BIND_SERVICE` is disallowed. In addition, all containers must explicitly drop `ALL` capabilities.                                                                                                                                                                                                |
-| disallow-capabilities          | Adding capabilities beyond those listed in the policy must be disallowed.                                                                                                                                                                                                                                                            |
-| disallow-host-namespaces       | Host namespaces (Process ID namespace, Inter-Process Communication namespace, and network namespace) allow access to shared information and can be used to elevate privileges. Pods should not be allowed access to host namespaces. This policy ensures fields which make use of these host namespaces are unset or set to `false`. |
-| disallow-host-path             | HostPath volumes let Pods use host directories and volumes in containers. Using host resources can be used to access shared data or escalate privileges and should not be allowed. This policy ensures no hostPath volumes are in use.                                                                                               |
-| disallow-host-ports            | Access to host ports allows potential snooping of network traffic and should not be allowed, or at minimum restricted to a known list. This policy ensures the `hostPort` field is unset or set to `0`.                                                                                                                              |
-| disallow-latest-tag            | The ':latest' tag is mutable and can lead to unexpected errors if the image changes. A best practice is to use an immutable tag that maps to a specific version of an application Pod. This policy validates that the image specifies a tag and that it is not called `latest`.                                                      |
-| disallow-privilege-escalation  | Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed. This policy ensures the `allowPrivilegeEscalation` field is set to `false`.                                                                                                                                                          |
-| disallow-privileged-containers | Privileged mode disables most security mechanisms and must not be allowed. This policy ensures Pods do not call for privileged mode.                                                                                                                                                                                                 |
-| disallow-proc-mount            | The default /proc masks are set up to reduce attack surface and should be required. This policy ensures nothing but the default procMount can be specified.                                                                                                                                                                          |
-| require-pod-probes             | Liveness and readiness probes need to be configured to correctly manage a Pod's lifecycle during deployments, restarts, and upgrades.                                                                                                                                                                                                |
-| require-run-as-nonroot         | Containers must be required to run as non-root users. This policy ensures `runAsNonRoot` is set to `true`. 2.                                                                                                                                                                                                                        |
-| restrict-sysctls               | Sysctls can disable security mechanisms or affect all containers on a host, and should be disallowed except for an allowed "safe" subset.                                                                                                                                                                                            |
-| unique-ingress-host-and-path   | This policy ensures that no Ingress can be created or updated unless it is globally unique with respect to host plus path  combination.                                                                                                                                                                                              |
+This package is based on the upstream [Kyverno][kyverno-github].
 
 ## Deployment
 
-You can deploy kyverno by running the following command in the root of
-the project:
+This package is deployed as part of **Policy Module** when you create a cluster with `furyctl` and `spec.distribution.modules.policy.type` is set to `kyverno`.
 
-```shell
-kustomize build | kubectl apply --server-side -f -
-```
+You can control whether the default policies are installed and customize enforcement under `spec.distribution.modules.policy.kyverno` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
-<!-- </KFD-DOCS> -->
+[kyverno-github]: https://github.com/kyverno/kyverno
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulespolicy
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulespolicy
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulespolicy
+
+<!-- </SD-DOCS> -->
 
 ## License
 


### PR DESCRIPTION
### Summary 💡

This PR replicates the documentation refactor defined in `module-aws` (#104) on this module: the docs are now furyctl/SD-centric and the legacy `Furyfile.yml` + `furyctl legacy vendor` + `kustomize build | kubectl apply` workflow has been removed.

The motivation: this documentation ends up on docs.sighup.io but still described the old legacy workflow and exposed internal implementation details (kustomize patches, raw manifests, image coordinates) that don't make sense on a public docs site.

Relates: sighupio/module-aws#104

### Description 📝

- **`README.md` (SD-DOCS block)**: removed the legacy `Usage`/`Prerequisites`/Gatekeeper & Kyverno manual-deployment sections (Furyfile, kustomize patches, emergency brake, screenshots). New `Usage` section explains the module is deployed automatically as part of SD by `furyctl`, with optional `furyctl.yaml` (`spec.distribution.modules.policy`) examples for **both** policy engines (Gatekeeper and Kyverno) and links to the configuration schema reference (EKSCluster / KFDDistribution / OnPremises). Kept the PSS tip in the Overview.
- **`katalog/*/README.md`**: rewritten to the shared template (Overview → Upstream project → Deployment → License). Kept the useful reference tables (SIGHUP base Gatekeeper rules, Kyverno default policies) as Overview content. Renamed the legacy `KFD-DOCS` markers to `SD-DOCS`.
- **GPM** (`katalog/gatekeeper/gpm`): the package README was the full upstream project README (Helm/Docker install, dev, roadmap); trimmed to the module package template pointing at the upstream project.

### Breaking Changes 💔

None, documentation only.

### Tests performed 🧪

- [x] No `Furyfile` / `furyctl legacy vendor` / `kustomize build | kubectl apply` references left inside the `SD-DOCS` blocks
- [x] `SD-DOCS` / `FOOTER` markers intact, no orphan reference links
- [x] `furyctl.yaml` snippet fields and enum values match the v1alpha2 schema (`type`, `gatekeeper.enforcementAction: deny`, `kyverno.validationFailureAction: Enforce`)
- [x] Visual review of the GitHub markdown rendering

### Future work 🔧

- Replicate the same template on the remaining modules.